### PR TITLE
add github pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "projects/svelte-add/adders/tailwindcss"]
 	path = projects/svelte-add/adders/tailwindcss
 	url = https://github.com/svelte-add/tailwindcss
+[submodule ".\\projects\\svelte-add\\adders\\github-pages"]
+	path = .\\projects\\svelte-add\\adders\\github-pages
+	url = https://github.com/manuel3108/svelte-add-github-pages.git

--- a/projects/svelte-add/index.js
+++ b/projects/svelte-add/index.js
@@ -19,7 +19,7 @@ export const exit = (text) => {
  * @typedef {"bootstrap" | "bulma" | "tailwindcss"} StyleFramework
  * @typedef {"graphql-server" | "mdsvex"} Other
  * @typedef {"eslint" | "prettier"} Quality
- * @typedef {"firebase-hosting"} Deploy
+ * @typedef {"firebase-hosting" | "github-pages"} Deploy
  */
 
 /** @type {Script[]} */
@@ -31,7 +31,7 @@ const others = ["graphql-server", "mdsvex"];
 /** @type {Quality[]} */
 const qualities = ["eslint", "prettier"];
 /** @type {Deploy[]} */
-const deploys = ["firebase-hosting"];
+const deploys = ["firebase-hosting", "github-pages"];
 
 /** @type {Record<StyleFramework, StyleLanguage>} */
 const styleLanguageForFramework = {

--- a/projects/svelte-add/package-versions.js
+++ b/projects/svelte-add/package-versions.js
@@ -11,6 +11,7 @@ export const packageVersions = {
 	"svelte-preprocess": "^4.9.5",
 	tailwindcss: "^2.2.16",
 	"vite-plugin-coffee": "^2.2.1",
+	"@sveltejs/adapter-static": "^1.0.0-next.20",
 };
 
 /** @typedef {typeof packageVersions | Record<string, string>} Dependencies */


### PR DESCRIPTION
Github pages can be used to host your static svelte-kit apps.
For more details see the readme [here](https://github.com/manuel3108/svelte-add-github-pages/blob/main/README.md).

I created a new method in the main `svelte-add` package to add an adapter to the current svelte-kit installation. We might need to add some checks, to see if the current application is really a `kit` application.

Other changes are minor.
Pipeline should work and pass as far as i can see.

If you want or feel ready for it, we can transfer this to the org. I already send you a transfer request, just in case :)
If we transfer it, we will need to change the gitmodules url.