### PR TITLE
Add link to Storybook adder

### DIFF
--- a/projects/svelte-add/README.md
+++ b/projects/svelte-add/README.md
@@ -37,6 +37,7 @@ In theory, these adders are the most likely to work correctly:
 - [**GraphQL server**](https://github.com/svelte-add/graphql-server) (out of date)
 - [**Jest**](https://github.com/rossyman/svelte-add-jest)
 - [**Pug**](https://github.com/Leftium/pug-adder)
+- [**Storybook**](https://storybook.js.org/docs/svelte/get-started/install)
 - [**Supabase**](https://github.com/joshnuss/svelte-supabase)
 - [**Vitest**](https://github.com/davipon/svelte-add-vitest)
 


### PR DESCRIPTION
Closes https://github.com/svelte-add/svelte-add/issues/133

It's not technically built using the `svelte-add` infrastructure, but it works in just the same way for users where it takes a project you've created and then augments it with the Storybook functionality, so it's probably worth documenting as there's no point in duplicating the functionality