### PR TITLE
Fixes #195: Don't auto lowercase html tags

### DIFF
--- a/projects/svelte-add/ast-io.js
+++ b/projects/svelte-add/ast-io.js
@@ -23,7 +23,7 @@ export const stringifyPostcssAst = (ast) => ast.toString();
  * @param {string} text
  * @returns {DomHandlerAst}
  */
-export const newDomHandlerAst = (text) => parseDocument(text, { recognizeSelfClosing: true });
+export const newDomHandlerAst = (text) => parseDocument(text, { recognizeSelfClosing: true, lowerCaseTags: false });
 
 /**
  * @param {DomHandlerAst} ast


### PR DESCRIPTION
Fixes #195.

Fixes the issue with lowercasing the "Header" tag, when i.e. the scss adder is added to a clean project, whicht was created with the `"demo": yes` option. 

I can confirm that after this change the text remains upper case. 

The parser documentation notes that we should use `xmlMode` of the parser. But that doesn't work out for us, because we rely on special handling of i.e. the script tag. 

With the current combination everything seems to work out great, as far as I can tell.