### PR TITLE
⚡ feat: improve package manager detection

### DIFF
--- a/projects/svelte-add/cli.js
+++ b/projects/svelte-add/cli.js
@@ -2,7 +2,7 @@
 import colors from "kleur";
 import mri from "mri";
 import { applyPreset, detectAdder, exit, getAdderInfo, getChoices, getEnvironment, getFolderInfo, installDependencies, packageManagers, runAdder } from "./index.js";
-import { detect } from "detect-package-manager";
+import { detect as detectPackageManager } from "detect-package-manager";
 
 // Show the package version to make debugging easier
 import { createRequire } from "module";
@@ -26,7 +26,17 @@ const main = async () => {
 	const passedFeatures = passedFeaturesJoined === "" ? undefined : passedFeaturesJoined.split("+");
 
 	const environment = await getEnvironment();
-	const detectedPackageManager = await detect();
+
+	/** @type {string | undefined} */
+	let detectedPackageManager;
+	try {
+		detectedPackageManager = await detectPackageManager();
+	} catch (error) {
+		// sometimes package manager detection fails, if globally checking
+		// if a package manager is installed. But we want to continue execution.
+		// See https://github.com/egoist/detect-package-manager/pull/7 for full explanation.
+		detectedPackageManager = undefined;
+	}
 	const { adderOptions, deploy, install, npx, packageManager, other, presets, projectDirectory, quality, script, styleFramework, styleLanguage } = await getChoices({
 		passedFeatures,
 		defaultInstall: false,

--- a/projects/svelte-add/index.js
+++ b/projects/svelte-add/index.js
@@ -445,7 +445,7 @@ export const getChoices = async ({ defaultInstall, environment, outputFolderMust
 			packageManager = passedPackageManager ?? defaultPackageManager;
 			npx = defaultNpx;
 		} else {
-			const defaultPackageManagerIndex = installedPackageManagers.indexOf(defaultPackageManager);
+			const defaultPackageManagerIndex = installedPackageManagers.indexOf(passedPackageManager ?? defaultPackageManager);
 
 			const { packageManagerOrUndefined } = await prompts({
 				choices: [
@@ -472,7 +472,7 @@ export const getChoices = async ({ defaultInstall, environment, outputFolderMust
 
 				install = true;
 			} else {
-				packageManager = defaultPackageManager;
+				packageManager = passedPackageManager ?? defaultPackageManager;
 				npx = defaultNpx;
 				install = false;
 			}


### PR DESCRIPTION
Based on #249 
* Fix exception when detection failed, because one of the checked package managers was not installed on the system
* Fix wrong displayed command, if no package manager was selected for installation in interactive mode.