### PR TITLE
fix: import `vitePreprocess` from `vite-plugin-svelte` in sveltekit

### DIFF
--- a/projects/svelte-add/adder-tools.js
+++ b/projects/svelte-add/adder-tools.js
@@ -66,7 +66,7 @@ export const updateSveltePreprocessArgs = async ({ folderInfo, mutateSveltePrepr
 	await updateJavaScript({
 		path: cjs ? "/svelte.config.js" : "/svelte.config.js",
 		async script({ typeScriptEstree }) {
-			const importFromPackage = folderInfo.kit ? "@sveltejs/kit/vite" : "@sveltejs/vite-plugin-svelte";
+			const importFromPackage = "@sveltejs/vite-plugin-svelte";
 
 			const sveltePreprocessImports = findImport({ cjs, package: importFromPackage, typeScriptEstree });
 			let sveltePreprocessImportedAs = sveltePreprocessImports.named.vitePreprocess;


### PR DESCRIPTION
As of sveltekit v2 `vitePreprocess` is no longer exported from `@sveltejs/kit/vite`, So `vitePreprocess` always is imported from `@sveltejs/vite-plugin-svelte`.

This fixes the bug where `vitePreprocess` is imported 2 times
