### PR TITLE
fix: install the correct `+layout.svelte` file for Tailwind adder

### DIFF
--- a/.changeset/cool-socks-punch.md
+++ b/.changeset/cool-socks-punch.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/tailwindcss": patch
+---
+
+fix: installs proper layout component file

--- a/.changeset/cool-socks-punch.md
+++ b/.changeset/cool-socks-punch.md
@@ -1,5 +1,0 @@
----
-"@svelte-add/tailwindcss": patch
----
-
-fix: installs proper layout component file

--- a/.changeset/ten-carrots-rescue.md
+++ b/.changeset/ten-carrots-rescue.md
@@ -1,0 +1,7 @@
+---
+"@svelte-add/tailwindcss": patch
+"@svelte-add/bootstrap": patch
+"@svelte-add/bulma": patch
+---
+
+fix: use layout.svelte instead of layout.js for adding global css

--- a/adders/bootstrap/config/adder.js
+++ b/adders/bootstrap/config/adder.js
@@ -92,14 +92,14 @@ export const adder = defineAdderConfig({
             },
         },
         {
-            name: ({ kit }) => `${kit.routesDirectory}/+layout.js`,
-            contentType: "script",
+            name: ({ kit }) => `${kit.routesDirectory}/+layout.svelte`,
+            contentType: "svelte",
             condition: ({ kit }) => kit.installed,
-            content: ({ ast, imports, options }) => {
+            content: ({ js, options }) => {
                 if (options.useSass) {
-                    imports.addEmpty(ast, "../app.scss");
+                    js.imports.addEmpty(js.ast, "../app.scss");
                 } else {
-                    imports.addEmpty(ast, "bootstrap/dist/css/bootstrap.css");
+                    js.imports.addEmpty(js.ast, "bootstrap/dist/css/bootstrap.css");
                 }
             },
         },

--- a/adders/bulma/config/adder.js
+++ b/adders/bulma/config/adder.js
@@ -61,14 +61,14 @@ export const adder = defineAdderConfig({
             },
         },
         {
-            name: ({ kit }) => `${kit.routesDirectory}/+layout.js`,
-            contentType: "script",
+            name: ({ kit }) => `${kit.routesDirectory}/+layout.svelte`,
+            contentType: "svelte",
             condition: ({ kit }) => kit.installed,
-            content: ({ ast, imports, options }) => {
+            content: ({ js, options }) => {
                 if (options.useSass) {
-                    imports.addEmpty(ast, "../app.scss");
+                    js.imports.addEmpty(js.ast, "../app.scss");
                 } else {
-                    imports.addEmpty(ast, "bulma/css/bulma.css");
+                    js.imports.addEmpty(js.ast, "bulma/css/bulma.css");
                 }
             },
         },

--- a/adders/tailwindcss/config/adder.js
+++ b/adders/tailwindcss/config/adder.js
@@ -82,10 +82,10 @@ export const adder = defineAdderConfig({
             condition: ({ kit }) => !kit.installed,
         },
         {
-            name: ({ kit }) => `${kit.routesDirectory}/+layout.js`,
-            contentType: "script",
-            content: ({ ast, imports }) => {
-                imports.addEmpty(ast, "../app.css");
+            name: ({ kit }) => `${kit.routesDirectory}/+layout.svelte`,
+            contentType: "svelte",
+            content: ({ js }) => {
+                js.imports.addEmpty(js.ast, "../app.css");
             },
             condition: ({ kit }) => kit.installed,
         },


### PR DESCRIPTION
For the tailwind adder, `+layout.js` was being installed instead of the needed `+layout.svelte` file.