### PR TITLE
fix: fixed spacing for `package.json`

### DIFF
--- a/.changeset/beige-avocados-kick.md
+++ b/.changeset/beige-avocados-kick.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: `package.json` spacing

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -128,7 +128,7 @@ export async function installPackages(config: InlineAdderConfig<OptionDefinition
         }
     }
 
-    const packageText = await format(workspace, commonFilePaths.packageJsonFilePath, JSON.stringify(content));
+    const packageText = await format(workspace, commonFilePaths.packageJsonFilePath, JSON.stringify(content, null, "\t"));
     await writeFile(workspace, commonFilePaths.packageJsonFilePath, packageText);
 }
 


### PR DESCRIPTION
After execution, the `package.json` would be completely collapsed without spacing like so:

 ```json
{"name":"toolbar-test","version":"0.0.1","private":true,"scripts":{"dev":"vite dev","build":"vite build","preview":"vite preview","check":"svelte-kit sync && svelte-check --tsconfig ./tsconfig.json","check:watch":"svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"},"devDependencies":{"@sveltejs/adapter-auto":"^3.0.0","@sveltejs/kit":"^2.0.0","@sveltejs/vite-plugin-svelte":"^3.0.0","autoprefixer":"^10.4.16","postcss":"^8.4.33","svelte":"^4.2.7","svelte-check":"^3.6.0","tailwindcss":"^3.4.1","tslib":"^2.4.1","typescript":"^5.0.0","vite":"^5.0.3"},"type":"module","dependencies":{"bits-ui":"^0.21.7","clsx":"^2.1.1","tailwind-merge":"^2.3.0","tailwind-variants":"^0.2.1"}}
```

This PR adds it back using tabs