### PR TITLE
fix: preserve json indentation 

### DIFF
--- a/.changeset/purple-ravens-wink.md
+++ b/.changeset/purple-ravens-wink.md
@@ -1,0 +1,6 @@
+---
+"@svelte-add/ast-tooling": patch
+"@svelte-add/core": patch
+---
+
+preserve json intendation

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -8,7 +8,7 @@ import { Root as CssAst, Declaration, Rule, AtRule, Comment } from "postcss";
 import { parse as postcssParse } from "postcss";
 import { namedTypes as AstTypes } from "ast-types";
 import * as AstKinds from "ast-types/gen/kinds";
-import * as fleece from "golden-fleece";
+import * as fleece from "silver-fleece";
 
 /**
  * Most of the AST tooling is pretty big in bundle size and bundling takes forever.
@@ -60,7 +60,10 @@ export function serializePostcss(ast: CssAst) {
 }
 
 export function parseHtml(content: string) {
-    return parseDocument(content, { recognizeSelfClosing: true, lowerCaseTags: false });
+    return parseDocument(content, {
+        recognizeSelfClosing: true,
+        lowerCaseTags: false,
+    });
 }
 
 export function serializeHtml(ast: Document) {

--- a/packages/ast-tooling/package.json
+++ b/packages/ast-tooling/package.json
@@ -12,15 +12,13 @@
         "domutils": "^3.1.0",
         "htmlparser2": "^9.1.0",
         "postcss": "^8.4.38",
-        "recast": "^0.23.6"
+        "recast": "^0.23.6",
+        "silver-fleece": "^1.1.0"
     },
     "bugs": "https://github.com/svelte-add/svelte-add/issues",
     "repository": {
         "type": "git",
         "url": "https://github.com/svelte-add/svelte-add/tree/main/projects/ast-tooling"
     },
-    "keywords": [],
-    "dependencies": {
-        "golden-fleece": "^1.0.9"
-    }
+    "keywords": []
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,19 +1,5 @@
-import {
-    defineAdderConfig,
-    defineAdderTests,
-    defineAdder,
-    defineAdderOptions,
-    defineAdderChecks,
-} from "./adder/config.js";
+import { defineAdderConfig, defineAdderTests, defineAdder, defineAdderOptions, defineAdderChecks } from "./adder/config.js";
 import { generateAdderInfo } from "./adder/execute.js";
 import { categories } from "./adder/categories.js";
 
-export {
-    defineAdderConfig,
-    generateAdderInfo,
-    defineAdder,
-    defineAdderTests,
-    defineAdderOptions,
-    defineAdderChecks,
-    categories,
-};
+export { defineAdderConfig, generateAdderInfo, defineAdder, defineAdderTests, defineAdderOptions, defineAdderChecks, categories };

--- a/packages/core/utils/common.ts
+++ b/packages/core/utils/common.ts
@@ -1,3 +1,4 @@
+import { parseJson } from "@svelte-add/ast-tooling";
 import { OptionDefinition } from "../adder/options.js";
 import { commonFilePaths, readFile } from "../files/utils.js";
 import { Workspace, WorkspaceWithoutExplicitArgs } from "./workspace.js";
@@ -13,13 +14,19 @@ export async function getPackageJson(workspace: WorkspaceWithoutExplicitArgs) {
     const packageText = await readFile(workspace, commonFilePaths.packageJsonFilePath);
     if (!packageText) {
         return {
-            dependencies: {},
-            devDependencies: {},
-            name: "",
-            version: "",
+            text: "",
+            data: {
+                dependencies: {},
+                devDependencies: {},
+                name: "",
+                version: "",
+            },
         };
     }
 
-    const packageJson: Package = JSON.parse(packageText);
-    return packageJson;
+    const packageJson: Package = parseJson(packageText);
+    return {
+        text: packageText,
+        data: packageJson,
+    };
 }

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -45,7 +45,7 @@ export async function detectSvelteDirectory(directoryPath: string): Promise<stri
 
     const emptyWorkspace = createEmptyWorkspace();
     emptyWorkspace.cwd = directoryPath;
-    const packageJson = await getPackageJson(emptyWorkspace);
+    const { data: packageJson } = await getPackageJson(emptyWorkspace);
 
     if (packageJson.devDependencies && "svelte" in packageJson.devDependencies) {
         return directoryPath;
@@ -105,5 +105,8 @@ export async function createProject(cwd: string) {
         return { projectCreated: false, directory: "" };
     }
 
-    return { projectCreated: true, directory: path.join(process.cwd(), directory) };
+    return {
+        projectCreated: true,
+        directory: path.join(process.cwd(), directory),
+    };
 }

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -70,7 +70,7 @@ export function addPropertyToWorkspaceOption(workspace: WorkspaceWithoutExplicit
 export async function populateWorkspaceDetails(workspace: WorkspaceWithoutExplicitArgs, workingDirectory: string) {
     workspace.cwd = workingDirectory;
 
-    const packageJson = await getPackageJson(workspace);
+    const { data: packageJson } = await getPackageJson(workspace);
     workspace.typescript.installed = "tslib" in packageJson.devDependencies;
     workspace.prettier.installed = "prettier" in packageJson.devDependencies;
     workspace.kit.installed = "@sveltejs/kit" in packageJson.devDependencies;

--- a/packages/testing-library/utils/test.ts
+++ b/packages/testing-library/utils/test.ts
@@ -2,11 +2,7 @@ import { AdderWithoutExplicitArgs, Tests } from "@svelte-add/core/adder/config";
 import { OptionValues, Question } from "@svelte-add/core/adder/options";
 import { Page } from "puppeteer";
 
-export async function runTests(
-    page: Page,
-    adder: AdderWithoutExplicitArgs,
-    options: OptionValues<Record<string, Question>>,
-) {
+export async function runTests(page: Page, adder: AdderWithoutExplicitArgs, options: OptionValues<Record<string, Question>>) {
     const tests: Tests = {
         expectProperty: async (selector, property, expectedValue) => {
             await expectProperty(page, selector, property, expectedValue);
@@ -30,8 +26,7 @@ async function executeAdderTests(
     testMethods: Tests,
     options: OptionValues<Record<string, Question>>,
 ) {
-    if (!adder.tests || !adder.tests.tests || adder.tests.tests.length == 0)
-        throw new Error(`Cannot test adder without tests!`);
+    if (!adder.tests || !adder.tests.tests || adder.tests.tests.length == 0) throw new Error(`Cannot test adder without tests!`);
 
     for (const test of adder.tests.tests) {
         if (test.condition && !test.condition(options)) continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,10 +115,6 @@ importers:
         version: link:../ast-tooling
 
   packages/ast-tooling:
-    dependencies:
-      golden-fleece:
-        specifier: ^1.0.9
-        version: 1.0.9
     devDependencies:
       '@babel/parser':
         specifier: ^7.24.5
@@ -144,6 +140,9 @@ importers:
       recast:
         specifier: ^0.23.6
         version: 0.23.6
+      silver-fleece:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/cli:
     dependencies:
@@ -1643,9 +1642,6 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
-  golden-fleece@1.0.9:
-    resolution: {integrity: sha512-YSwLaGMOgSBx9roJlNLL12c+FRiw7VECphinc6mGucphc/ZxTHgdEz6gmJqH6NOzYEd/yr64hwjom5pZ+tJVpg==}
-
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
@@ -2498,6 +2494,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  silver-fleece@1.1.0:
+    resolution: {integrity: sha512-V3vShUiLRVPMu9aSWpU5kLDoU/HO7muJKE236EO663po3YxivAkMLbRg+amV/FhbIfF5bWXX5TVX+VYmRaOBFA==}
 
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
@@ -4550,8 +4549,6 @@ snapshots:
 
   globrex@0.1.2: {}
 
-  golden-fleece@1.0.9: {}
-
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
@@ -5392,6 +5389,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  silver-fleece@1.1.0: {}
 
   sirv@2.0.4:
     dependencies:


### PR DESCRIPTION
Similar to #344, this change will preserve the JSON indentation if no prettier installation / config could be determined. 

As an improvement over #344 this change will keep the user chosen indentation (2 spaces, 4 spaces, tabs, etc.) and not convert everything to tabs.