### PR TITLE
fix: corrects the `@tailwind` directive order and adds optional semicolon in `app.css`

### DIFF
--- a/.changeset/bright-cooks-push.md
+++ b/.changeset/bright-cooks-push.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: always add the optional semicolon in stylesheets

--- a/.changeset/heavy-beers-sell.md
+++ b/.changeset/heavy-beers-sell.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/tailwindcss": patch
+---
+
+fix: corrected the declaration order of the `@tailwind` directives

--- a/adders/tailwindcss/config/adder.js
+++ b/adders/tailwindcss/config/adder.js
@@ -67,7 +67,7 @@ export const adder = defineAdderConfig({
             name: () => "src/app.css",
             contentType: "css",
             content: ({ ast, addAtRule }) => {
-                const atRules = ["base", "components", "utilities"];
+                const atRules = ["utilities", "components", "base"];
                 for (const name of atRules) {
                     addAtRule(ast, "tailwind", name);
                 }

--- a/packages/core/files/processors.ts
+++ b/packages/core/files/processors.ts
@@ -130,6 +130,7 @@ function handleCssFile<Args extends OptionDefinition>(
     workspace: Workspace<Args>,
 ) {
     const ast = parsePostcss(content);
+    ast.raws.semicolon = true; // always add the optional semicolon
     fileDetails.content({ ...getCssAstEditor(ast), ...workspace });
     content = serializePostcss(ast);
     return content;


### PR DESCRIPTION
Here's the current output of the `app.css` file for the Tailwind adder:
```css
@tailwind utilities;
@tailwind components;
@tailwind base
```

There are 2 issues that can be found above:
- The order of the `@tailwind` directives is upside-down. Instead, it should be: `base`, `components`, `utilities`.
- `@tailwind base` is missing the semicolon at the end. While it _does work_ without it in practice, it simply looks nicer and is less confusing with it always being added.

This PR addresses both.