### PR TITLE
fix: add slot element for layouts

### DIFF
--- a/.changeset/new-pugs-appear.md
+++ b/.changeset/new-pugs-appear.md
@@ -1,0 +1,7 @@
+---
+"@svelte-add/tailwindcss": patch
+"@svelte-add/bootstrap": patch
+"@svelte-add/bulma": patch
+---
+
+fix: include `<slot>` element for `+layout.svelte` files

--- a/adders/bootstrap/config/adder.js
+++ b/adders/bootstrap/config/adder.js
@@ -95,12 +95,14 @@ export const adder = defineAdderConfig({
             name: ({ kit }) => `${kit.routesDirectory}/+layout.svelte`,
             contentType: "svelte",
             condition: ({ kit }) => kit.installed,
-            content: ({ js, options }) => {
+            content: ({ js, options, html }) => {
                 if (options.useSass) {
                     js.imports.addEmpty(js.ast, "../app.scss");
                 } else {
                     js.imports.addEmpty(js.ast, "bootstrap/dist/css/bootstrap.css");
                 }
+                const slot = html.element("slot");
+                html.ast.childNodes.push(slot);
             },
         },
         {

--- a/adders/bulma/config/adder.js
+++ b/adders/bulma/config/adder.js
@@ -64,12 +64,14 @@ export const adder = defineAdderConfig({
             name: ({ kit }) => `${kit.routesDirectory}/+layout.svelte`,
             contentType: "svelte",
             condition: ({ kit }) => kit.installed,
-            content: ({ js, options }) => {
+            content: ({ js, options, html }) => {
                 if (options.useSass) {
                     js.imports.addEmpty(js.ast, "../app.scss");
                 } else {
                     js.imports.addEmpty(js.ast, "bulma/css/bulma.css");
                 }
+                const slot = html.element("slot");
+                html.ast.childNodes.push(slot);
             },
         },
         {

--- a/adders/tailwindcss/config/adder.js
+++ b/adders/tailwindcss/config/adder.js
@@ -84,8 +84,10 @@ export const adder = defineAdderConfig({
         {
             name: ({ kit }) => `${kit.routesDirectory}/+layout.svelte`,
             contentType: "svelte",
-            content: ({ js }) => {
+            content: ({ js, html }) => {
                 js.imports.addEmpty(js.ast, "../app.css");
+                const slot = html.element("slot");
+                html.ast.childNodes.push(slot);
             },
             condition: ({ kit }) => kit.installed,
         },


### PR DESCRIPTION
Generated `+layout.svelte` files were missing their corresponding `slot` elements. Not quite sure how I missed this during the fix of #343 🤦‍♂️