### PR TITLE
chore: Enable `strict` mode and adders install dependencies directly

### DIFF
--- a/.changeset/funny-bags-suffer.md
+++ b/.changeset/funny-bags-suffer.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+feat: dependencies are now installed automatically if a package manager can be detected

--- a/.changeset/red-jars-press.md
+++ b/.changeset/red-jars-press.md
@@ -1,0 +1,10 @@
+---
+"@svelte-add/ast-manipulation": patch
+"@svelte-add/testing-library": patch
+"@svelte-add/ast-tooling": patch
+"@svelte-add/bootstrap": patch
+"@svelte-add/core": patch
+"svelte-add": patch
+---
+
+chore: enabled `strict` mode and fixed types

--- a/adders/bootstrap/config/adder.js
+++ b/adders/bootstrap/config/adder.js
@@ -28,7 +28,7 @@ export const adder = defineAdderConfig({
             contentType: "css",
             condition: ({ options }) => options.useSass,
             content: ({ ast, addAtRule, addComment, addDeclaration }) => {
-                const baseImport = (component) => `"bootstrap/scss/${component}"`;
+                const baseImport = (/** @type {string} */ component) => `"bootstrap/scss/${component}"`;
                 const importRule = "import";
 
                 addComment(ast, "1. Include functions first (so you can manipulate colors, SVGs, calc, etc)");

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.6",
         "@svitejs/changesets-changelog-github-compact": "^1.1.0",
+        "@types/eslint__js": "^8.42.3",
         "@types/node": "^20.12.7",
         "autoprefixer": "^10.4.19",
         "eslint": "^9.1.1",

--- a/packages/ast-manipulation/css/index.ts
+++ b/packages/ast-manipulation/css/index.ts
@@ -21,7 +21,7 @@ export function getCssAstEditor(ast: CssAst) {
 }
 
 export function addRule(ast: CssAst, selector: string): Rule {
-    const rules = ast.nodes.filter((x) => x.type == "rule") as Rule[];
+    const rules = ast.nodes.filter((x): x is Rule => x.type == "rule");
     let rule = rules.find((x) => x.selector == selector);
 
     if (!rule) {
@@ -34,7 +34,7 @@ export function addRule(ast: CssAst, selector: string): Rule {
 }
 
 export function addDeclaration(ast: Rule | CssAst, property: string, value: string) {
-    const declarations = ast.nodes.filter((x) => x.type == "decl") as Declaration[];
+    const declarations = ast.nodes.filter((x): x is Declaration => x.type == "decl");
     let declaration = declarations.find((x) => x.prop == property);
 
     if (!declaration) {
@@ -46,7 +46,7 @@ export function addDeclaration(ast: Rule | CssAst, property: string, value: stri
 }
 
 export function addAtRule(ast: CssAst, name: string, params: string, append = false): AtRule {
-    const atRules = ast.nodes.filter((x) => x.type == "atrule") as AtRule[];
+    const atRules = ast.nodes.filter((x): x is AtRule => x.type == "atrule");
     let atRule = atRules.find((x) => x.name == name && x.params == params);
 
     if (atRule) {

--- a/packages/ast-manipulation/js/array.ts
+++ b/packages/ast-manipulation/js/array.ts
@@ -11,7 +11,7 @@ export function createEmpty() {
 
 export function push(ast: AstTypes.ArrayExpression, data: string | AstKinds.ExpressionKind) {
     if (typeof data === "string") {
-        const existingLiterals = ast.elements.filter((x) => x?.type == "StringLiteral") as AstTypes.StringLiteral[];
+        const existingLiterals = ast.elements.filter((x): x is AstTypes.StringLiteral => x?.type == "StringLiteral");
         let literal = existingLiterals.find((x) => x.value == data);
 
         if (!literal) {

--- a/packages/ast-manipulation/js/exports.ts
+++ b/packages/ast-manipulation/js/exports.ts
@@ -26,7 +26,7 @@ export function defaultExport<T extends AstKinds.ExpressionKind>(
         // in this case the export default declaration is only referencing a variable, get that variable
         const exportDefaultDeclarationDeclaration = exportDefaultDeclaration.declaration as AstTypes.Identifier;
 
-        const variableDeclarations = ast.body.filter((x) => x.type == "VariableDeclaration") as AstTypes.VariableDeclaration[];
+        const variableDeclarations = ast.body.filter((x): x is AstTypes.VariableDeclaration => x.type == "VariableDeclaration");
         const variableDeclaration = variableDeclarations.find((x) => {
             const variableDeclaration = x.declarations[0] as AstTypes.VariableDeclarator;
             const variableIdentifier = variableDeclaration.id as AstTypes.Identifier;
@@ -48,7 +48,7 @@ export function defaultExport<T extends AstKinds.ExpressionKind>(
 }
 
 export function namedExport(ast: AstTypes.Program, name: string, fallback: AstTypes.VariableDeclaration) {
-    const namedExports = ast.body.filter((x) => x.type == "ExportNamedDeclaration") as AstTypes.ExportNamedDeclaration[];
+    const namedExports = ast.body.filter((x): x is AstTypes.ExportNamedDeclaration => x.type == "ExportNamedDeclaration");
     let namedExport = namedExports.find((x) => {
         const variableDeclaration = x.declaration as AstTypes.VariableDeclaration;
         const variableDeclarator = variableDeclaration.declarations[0] as AstTypes.VariableDeclarator;

--- a/packages/ast-manipulation/js/imports.ts
+++ b/packages/ast-manipulation/js/imports.ts
@@ -36,17 +36,8 @@ export function addDefault(ast: AstTypes.Program, importFrom: string, importAs: 
 }
 
 export function addNamed(ast: AstTypes.Program, importFrom: string, exportedAsImportAs: Record<string, string>) {
-    const expectedImportDeclaration: AstTypes.ImportDeclaration = {
-        type: "ImportDeclaration",
-        source: {
-            type: "Literal",
-            value: importFrom,
-        },
-        specifiers: [],
-    };
-
-    for (const [key, value] of Object.entries(exportedAsImportAs)) {
-        const importSpecifier: AstTypes.ImportSpecifier = {
+    const specifiers = Object.entries(exportedAsImportAs).map(([key, value]) => {
+        const specifier: AstTypes.ImportSpecifier = {
             type: "ImportSpecifier",
             imported: {
                 type: "Identifier",
@@ -57,9 +48,17 @@ export function addNamed(ast: AstTypes.Program, importFrom: string, exportedAsIm
                 name: value,
             },
         };
+        return specifier;
+    });
 
-        expectedImportDeclaration.specifiers.push(importSpecifier);
-    }
+    const expectedImportDeclaration: AstTypes.ImportDeclaration = {
+        type: "ImportDeclaration",
+        source: {
+            type: "Literal",
+            value: importFrom,
+        },
+        specifiers,
+    };
 
     addImportIfNecessary(ast, expectedImportDeclaration);
 }

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -6,8 +6,7 @@ export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier
     fallback: T,
 ): T {
     const objectExpression = ast;
-    const properties =
-        (objectExpression.properties?.filter((x) => x.type == "ObjectProperty") as AstTypes.ObjectProperty[]) ?? [];
+    const properties = objectExpression.properties.filter((x): x is AstTypes.ObjectProperty => x.type == "ObjectProperty") ?? [];
     let property = properties.find((x) => (x.key as AstTypes.Identifier).name == name);
     let propertyValue: T;
 
@@ -40,7 +39,7 @@ export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier
 
 export function overrideProperty<T extends AstKinds.ExpressionKind>(ast: AstTypes.ObjectExpression, name: string, value: T) {
     const objectExpression = ast;
-    const properties = objectExpression.properties.filter((x) => x.type == "ObjectProperty") as AstTypes.ObjectProperty[];
+    const properties = objectExpression.properties.filter((x): x is AstTypes.ObjectProperty => x.type == "ObjectProperty");
     const property = properties.find((x) => (x.key as AstTypes.Identifier).name == name);
 
     if (!property) {

--- a/packages/ast-manipulation/js/variables.ts
+++ b/packages/ast-manipulation/js/variables.ts
@@ -1,7 +1,7 @@
 import { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export function declaration(ast: AstTypes.Program, kind: "const" | "let" | "var", name: string, value: AstKinds.ExpressionKind) {
-    const declarations = ast.body.filter((x) => x.type == "VariableDeclaration") as AstTypes.VariableDeclaration[];
+    const declarations = ast.body.filter((x): x is AstTypes.VariableDeclaration => x.type == "VariableDeclaration");
     let declaration = declarations.find((x) => {
         const declarator = x.declarations[0] as AstTypes.VariableDeclarator;
         const identifier = declarator.id as AstTypes.Identifier;

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -76,7 +76,7 @@ export type SvelteAst = {
     cssAst: CssAst;
 };
 
-export function parseSvelteFile(content): SvelteAst {
+export function parseSvelteFile(content: string): SvelteAst {
     const htmlAst = parseHtml(content);
 
     let scriptTag, styleTag: Element | undefined;

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -44,7 +44,7 @@ async function executeCli() {
 
     for (const adder of filteredAdders) {
         const adderId = adder.config.metadata.id;
-        const adderOptions = {};
+        const adderOptions: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(options)) {
             if (!key || !key.startsWith(adderId)) continue;
 
@@ -110,7 +110,7 @@ async function askForAddersToApply(adders: AdderWithoutExplicitArgs[]): Promise<
         currentCategory++;
         const categoryDetails = categories[categoryId];
 
-        const promptOptions: PromptOption[] = [];
+        const promptOptions: PromptOption<string>[] = [];
         for (const adder of adders) {
             const adderMetadata = adder.config.metadata;
             promptOptions.push({

--- a/packages/core/adder/options.ts
+++ b/packages/core/adder/options.ts
@@ -1,7 +1,7 @@
-import { OptionValues as CliOptionValues, program } from "commander";
+import { type OptionValues as CliOptionValues, program } from "commander";
 import { booleanPrompt, endPrompts, startPrompts, textPrompt } from "../utils/prompts.js";
-import { Workspace, WorkspaceWithoutExplicitArgs, addPropertyToWorkspaceOption } from "../utils/workspace.js";
-import { AdderConfig, AdderConfigWithoutExplicitArgs } from "./config.js";
+import { type Workspace, addPropertyToWorkspaceOption } from "../utils/workspace.js";
+import type { AdderConfig } from "./config.js";
 
 export type BooleanDefaultValue = {
     type: "boolean";
@@ -38,7 +38,7 @@ export type OptionValues<Args extends OptionDefinition> = {
             : never;
 };
 
-export function prepareAndParseCliOptions(config: AdderConfigWithoutExplicitArgs) {
+export function prepareAndParseCliOptions<Args extends OptionDefinition>(config: AdderConfig<Args>) {
     program.option("--path <string>", "Path to working directory");
 
     if (config.options) {
@@ -54,9 +54,9 @@ export function prepareAndParseCliOptions(config: AdderConfigWithoutExplicitArgs
     return options;
 }
 
-export async function askQuestionsAndAssignValuesToWorkspace(
-    config: AdderConfigWithoutExplicitArgs,
-    workspace: WorkspaceWithoutExplicitArgs,
+export async function askQuestionsAndAssignValuesToWorkspace<Args extends OptionDefinition>(
+    config: AdderConfig<Args>,
+    workspace: Workspace<Args>,
     cliOptions: CliOptionValues,
 ) {
     if (!config.options) return;
@@ -98,7 +98,7 @@ export async function askQuestionsAndAssignValuesToWorkspace(
     }
 }
 
-export function ensureCorrectOptionTypes(config: AdderConfigWithoutExplicitArgs, workspace: WorkspaceWithoutExplicitArgs) {
+export function ensureCorrectOptionTypes<Args extends OptionDefinition>(config: AdderConfig<Args>, workspace: Workspace<Args>) {
     if (!config.options) {
         return;
     }

--- a/packages/core/files/utils.ts
+++ b/packages/core/files/utils.ts
@@ -1,8 +1,7 @@
 import fs from "fs/promises";
 import path from "node:path";
 import prettier from "prettier";
-import { OptionDefinition } from "../adder/options";
-import { Workspace, WorkspaceWithoutExplicitArgs } from "../utils/workspace";
+import type { WorkspaceWithoutExplicitArgs } from "../utils/workspace";
 
 export async function readFile(workspace: WorkspaceWithoutExplicitArgs, filePath: string) {
     const fullFilePath = getFilePath(workspace.cwd, filePath);

--- a/packages/core/utils/common.ts
+++ b/packages/core/utils/common.ts
@@ -1,7 +1,7 @@
 import { parseJson } from "@svelte-add/ast-tooling";
 import { commonFilePaths, readFile } from "../files/utils.js";
-import { WorkspaceWithoutExplicitArgs } from "./workspace.js";
-import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import type { WorkspaceWithoutExplicitArgs } from "./workspace.js";
+import { type ChildProcess, spawn } from "child_process";
 
 export type Package = {
     name: string;
@@ -36,7 +36,7 @@ export async function executeCli(
     commandArgs: string[],
     cwd: string,
     options?: {
-        onData?: (data: string, program: ChildProcessWithoutNullStreams, resolve: (value: any) => any) => void;
+        onData?: (data: string, program: ChildProcess, resolve: (value: any) => any) => void;
         stdio?: "pipe" | "inherit";
         env?: Record<string, string>;
     },
@@ -44,7 +44,7 @@ export async function executeCli(
     const stdio = options?.stdio ?? "pipe";
     const env = options?.env ?? process.env;
 
-    const program = await spawn(command, commandArgs, { stdio, shell: true, cwd, env });
+    const program = spawn(command, commandArgs, { stdio, shell: true, cwd, env });
 
     return await new Promise((resolve, reject) => {
         let errorText = "";
@@ -55,7 +55,7 @@ export async function executeCli(
 
         program.stdout?.on("data", (data) => {
             const value = data.toString();
-            if (options?.onData) options?.onData(value, program, resolve);
+            options?.onData?.(value, program, resolve);
         });
 
         program.on("exit", (code) => {

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -81,10 +81,10 @@ export async function createProject(cwd: string) {
 
     let language = "js";
     if (projectType == "svelte") {
-        language = (await selectPrompt("Choose language", language, [
+        language = await selectPrompt("Choose language", language, [
             { label: "JavaScript", value: "js" },
             { label: "TypeScript", value: "ts" },
-        ])) as string;
+        ]);
     }
 
     endPrompts("Initializing template...");

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -1,8 +1,8 @@
-import { AstTypes, parseScript } from "@svelte-add/ast-tooling";
+import { type AstTypes, parseScript } from "@svelte-add/ast-tooling";
 import { getPackageJson } from "./common.js";
 import { commonFilePaths, readFile } from "../files/utils.js";
 import { getJsAstEditor } from "@svelte-add/ast-manipulation";
-import { OptionDefinition, OptionValues, Question } from "../adder/options.js";
+import type { OptionDefinition, OptionValues } from "../adder/options.js";
 
 export type PrettierData = {
     installed: boolean;
@@ -28,9 +28,9 @@ export type Workspace<Args extends OptionDefinition> = {
     kit: SvelteKitData;
 };
 
-export type WorkspaceWithoutExplicitArgs = Workspace<Record<string, Question>>;
+export type WorkspaceWithoutExplicitArgs = Workspace<any>;
 
-export function createEmptyWorkspace(): WorkspaceWithoutExplicitArgs {
+export function createEmptyWorkspace<Args extends OptionDefinition>(): Workspace<Args> {
     return {
         options: {},
         cwd: "",
@@ -47,7 +47,7 @@ export function createEmptyWorkspace(): WorkspaceWithoutExplicitArgs {
             routesDirectory: "src/routes",
             libDirectory: "src/lib",
         },
-    };
+    } as Workspace<Args>;
 }
 
 export function addPropertyToWorkspaceOption(workspace: WorkspaceWithoutExplicitArgs, optionKey: string, value: unknown) {

--- a/packages/dev-utils/utils/update-packages.js
+++ b/packages/dev-utils/utils/update-packages.js
@@ -26,7 +26,7 @@ function updateAdderPackage(data, adder) {
     data.repository = {};
     data.repository.type = "git";
     data.repository.url = `${repoUrl}/tree/main/adders/${adder.metadata.id}`;
-    data.keywords = adder.metadata.website.keywords;
+    data.keywords = adder.metadata.website?.keywords;
     data.keywords.push("svelte");
     data.keywords.push("kit");
     data.keywords.push("svelte-kit");

--- a/packages/testing-library/utils/adder.ts
+++ b/packages/testing-library/utils/adder.ts
@@ -1,6 +1,6 @@
-import { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
-import { OptionValues, Question } from "@svelte-add/core/adder/options";
-import { RemoteControlOptions } from "@svelte-add/core/adder/remoteControl";
+import type { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
+import type { OptionValues, Question } from "@svelte-add/core/adder/options";
+import type { RemoteControlOptions } from "@svelte-add/core/adder/remoteControl";
 import { createEmptyWorkspace, createOrUpdateFiles, executeAdder, populateWorkspaceDetails } from "@svelte-add/core/internal";
 
 export async function runAdder(
@@ -17,5 +17,5 @@ export async function runAdder(
     workspace.options = optionValues;
 
     await populateWorkspaceDetails(workspace, workingDirectory);
-    await createOrUpdateFiles(adder.tests.files, workspace);
+    await createOrUpdateFiles(adder.tests?.files ?? [], workspace);
 }

--- a/packages/testing-library/utils/dev-server.ts
+++ b/packages/testing-library/utils/dev-server.ts
@@ -39,7 +39,7 @@ async function forceKill(devServer: ChildProcessWithoutNullStreams): Promise<voi
     return new Promise((resolve) => {
         // just killing the process was not enough, because the process itself
         // spawns child process, that also need to be killed!
-        terminate(devServer.pid, () => {
+        terminate(devServer.pid!, () => {
             resolve();
         });
     });

--- a/packages/testing-library/utils/test.ts
+++ b/packages/testing-library/utils/test.ts
@@ -68,7 +68,6 @@ async function expectProperty(page: Page, selector: string, property: string, ex
     const elementToCheck = await elementExists(page, selector);
 
     const computedStyle = await page.evaluate(
-        // eslint-disable-next-line no-undef
         (element, pV) => window.getComputedStyle(element).getPropertyValue(pV),
         elementToCheck,
         property,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.1.0
         version: 1.1.0
+      '@types/eslint__js':
+        specifier: ^8.42.3
+        version: 8.42.3
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
@@ -46,7 +49,7 @@ importers:
         version: 9.1.0(eslint@9.1.1)
       eslint-plugin-prettier:
         specifier: ^5.1.3
-        version: 5.1.3(eslint-config-prettier@9.1.0(eslint@9.1.1))(eslint@9.1.1)(prettier@3.2.5)
+        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.1.1))(eslint@9.1.1)(prettier@3.2.5)
       globals:
         specifier: ^15.1.0
         version: 15.1.0
@@ -867,8 +870,17 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/eslint@8.56.10':
+    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
+
+  '@types/eslint__js@8.42.3':
+    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
+
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -3643,7 +3655,18 @@ snapshots:
 
   '@types/cookie@0.6.0': {}
 
+  '@types/eslint@8.56.10':
+    dependencies:
+      '@types/estree': 1.0.5
+      '@types/json-schema': 7.0.15
+
+  '@types/eslint__js@8.42.3':
+    dependencies:
+      '@types/eslint': 8.56.10
+
   '@types/estree@1.0.5': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/minimist@1.2.5': {}
 
@@ -4241,13 +4264,14 @@ snapshots:
     dependencies:
       eslint: 9.1.1
 
-  eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0(eslint@9.1.1))(eslint@9.1.1)(prettier@3.2.5):
+  eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.1.1))(eslint@9.1.1)(prettier@3.2.5):
     dependencies:
       eslint: 9.1.1
       prettier: 3.2.5
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
     optionalDependencies:
+      '@types/eslint': 8.56.10
       eslint-config-prettier: 9.1.0(eslint@9.1.1)
 
   eslint-scope@8.0.1:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,10 @@ const adderFolders = fs
     .map((item) => item.name);
 const adderNamesAsString = adderFolders.map((x) => `"${x}"`);
 
+/**
+ * @param {string} project
+ * @param {boolean} isAdder
+ */
 function getConfig(project, isAdder) {
     const inputs = [];
     let outDir = "";
@@ -47,6 +51,7 @@ function getConfig(project, isAdder) {
             dir: outDir,
             format: "esm",
             sourcemap: true,
+            intro: project === "cli" ? `const ADDER_LIST = [${adderNamesAsString}];` : undefined,
         },
         external: [/^@svelte-add.*/, "prettier", "create-svelte", "puppeteer"],
         plugins: [
@@ -58,10 +63,6 @@ function getConfig(project, isAdder) {
             dynamicImportVars(),
         ],
     };
-
-    if (project == "cli") {
-        config.output.intro = `const ADDER_LIST = [${adderNamesAsString}];`;
-    }
 
     return config;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "exclude": ["**/build/**", "**/temp/**", "**/website/**", "**/node_modules/**", "**/coverage/**"],
+    "exclude": ["**/build/**", "**/temp/**", "**/website/**", "**/coverage/**"],
     "compilerOptions": {
         "checkJs": true,
         "module": "es2022",
@@ -10,6 +10,7 @@
         "declaration": true,
         "allowSyntheticDefaultImports": true,
         "sourceMap": true,
+        "strict": true,
         "outDir": "build/"
     }
 }


### PR DESCRIPTION
closes #351
closes #355

This PR enables TS's [strict mode](https://www.typescriptlang.org/tsconfig/#strict) and fixes several spots where the types were failing. I also took the liberty of fixing #355 as the logic had to be adjusted anyway to better satisfy the new type requirements.

Additional notes for this PR can be seen below 👇