### PR TITLE
chore: slightly speed up tests by using `pnpm` instead of `npm`

### DIFF
--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -94,7 +94,7 @@ export async function createProject(cwd: string) {
         args = ["init", "svelte@latest", directory];
     } else {
         const template = language == "ts" ? "svelte-ts" : "svelte";
-        args = ["init", "vite@latest", directory, "--template", template];
+        args = ["init", "vite@latest", directory, "--", "--template", template];
     }
 
     try {

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -91,14 +91,14 @@ export async function createProject(cwd: string) {
 
     let args = [];
     if (projectType == "kit") {
-        args = ["create", "svelte@latest", directory];
+        args = ["init", "svelte@latest", directory];
     } else {
         const template = language == "ts" ? "svelte-ts" : "svelte";
-        args = ["create", "vite@latest", directory, "--template", template];
+        args = ["init", "vite@latest", directory, "--template", template];
     }
 
     try {
-        await executeCli("pnpm", args, process.cwd(), { stdio: "inherit" });
+        await executeCli("npm", args, process.cwd(), { stdio: "inherit" });
     } catch (error) {
         console.log("cancelled or failed " + error);
         return { projectCreated: false, directory: "" };

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -91,14 +91,14 @@ export async function createProject(cwd: string) {
 
     let args = [];
     if (projectType == "kit") {
-        args = ["init", "svelte@latest", directory];
+        args = ["create", "svelte@latest", directory];
     } else {
         const template = language == "ts" ? "svelte-ts" : "svelte";
-        args = ["init", "vite@latest", directory, "--", "--template", template];
+        args = ["create", "vite@latest", directory, "--template", template];
     }
 
     try {
-        await executeCli("npm", args, process.cwd(), { stdio: "inherit" });
+        await executeCli("pnpm", args, process.cwd(), { stdio: "inherit" });
     } catch (error) {
         console.log("cancelled or failed " + error);
         return { projectCreated: false, directory: "" };

--- a/packages/testing-library/utils/create-project.ts
+++ b/packages/testing-library/utils/create-project.ts
@@ -32,10 +32,10 @@ export async function createProject(output: string, projectType: string) {
         });
     } else {
         const template = projectType == ProjectTypes.Svelte_TS ? "svelte-ts" : "svelte";
-        let args = ["init", "vite@latest", projectType, "--yes", "--", "--template", template];
+        let args = ["create", "vite@latest", projectType, "--yes", "--template", template];
 
         try {
-            await executeCli("npm", args, join(output, ".."));
+            await executeCli("pnpm", args, join(output, ".."));
         } catch (error) {
             throw new Error("Failed initializing vite project: " + error);
         }

--- a/packages/testing-library/utils/workspace.ts
+++ b/packages/testing-library/utils/workspace.ts
@@ -11,7 +11,7 @@ export function getTemplatesDirectory(options: TestOptions) {
 
 export async function installDependencies(output: string) {
     try {
-        await executeCli("pnpm", ["install"], output, { stdio: "pipe" });
+        await executeCli("pnpm", ["install", "--ignore-workspace"], output, { stdio: "pipe" });
     } catch (error) {
         throw new Error("unable to install dependencies: " + error);
     }

--- a/packages/testing-library/utils/workspace.ts
+++ b/packages/testing-library/utils/workspace.ts
@@ -11,7 +11,7 @@ export function getTemplatesDirectory(options: TestOptions) {
 
 export async function installDependencies(output: string) {
     try {
-        await executeCli("npm", ["install"], output, { stdio: "pipe" });
+        await executeCli("pnpm", ["install"], output, { stdio: "pipe" });
     } catch (error) {
         throw new Error("unable to install dependencies: " + error);
     }


### PR DESCRIPTION
This PR is a bit of an experiment to see if using `pnpm` is faster for tests than `npm`. It's noticeably faster on my machine (most of the time, using `npm` just hangs and it takes ages to complete), however I'm curious to see the effects of it in CI.