### PR TITLE
chore: correctly type annotate `tailwind.config.ts`'s config when using typescript

### DIFF
--- a/.changeset/nasty-pants-perform.md
+++ b/.changeset/nasty-pants-perform.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/ast-manipulation": patch
+---
+
+added ability to add type annotations to expressions

--- a/.changeset/slimy-comics-know.md
+++ b/.changeset/slimy-comics-know.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/tailwindcss": patch
+---
+
+chore: correctly type annotate the tailwind config when using typescript

--- a/adders/tailwindcss/config/adder.js
+++ b/adders/tailwindcss/config/adder.js
@@ -38,7 +38,7 @@ export const adder = defineAdderConfig({
                 let rootExport = object.createEmpty();
                 if (typescript.installed) {
                     imports.addNamed(ast, "tailwindcss", { Config: "Config" }, true);
-                    root = common.annotateExpression(rootExport, "Config");
+                    root = common.typeAnnotateExpression(rootExport, "Config");
                 }
 
                 const { astNode: exportDeclaration } = exports.defaultExport(ast, root ?? rootExport);

--- a/adders/tailwindcss/config/adder.js
+++ b/adders/tailwindcss/config/adder.js
@@ -33,10 +33,17 @@ export const adder = defineAdderConfig({
         {
             name: ({ typescript }) => `tailwind.config.${typescript.installed ? "ts" : "js"}`,
             contentType: "script",
-            content: ({ options, ast, array, object, common, functions, exports }) => {
-                const { astNode: exportDeclaration, value: rootExport } = exports.defaultExport(ast, object.createEmpty());
+            content: ({ options, ast, array, object, common, functions, exports, typescript, imports }) => {
+                let root;
+                let rootExport = object.createEmpty();
+                if (typescript.installed) {
+                    imports.addNamed(ast, "tailwindcss", { Config: "Config" }, true);
+                    root = common.annotateExpression(rootExport, "Config");
+                }
 
-                common.addJsDocTypeComment(exportDeclaration, "import('tailwindcss').Config");
+                const { astNode: exportDeclaration } = exports.defaultExport(ast, root ?? rootExport);
+
+                if (!typescript.installed) common.addJsDocTypeComment(exportDeclaration, "import('tailwindcss').Config");
 
                 const contentArray = object.property(rootExport, "content", array.createEmpty());
                 array.push(contentArray, "./src/**/*.{html,js,svelte,ts}");

--- a/packages/ast-manipulation/js/common.ts
+++ b/packages/ast-manipulation/js/common.ts
@@ -11,6 +11,16 @@ export function addJsDocTypeComment(node: AstTypes.Node, type: string) {
     node.comments.push(comment);
 }
 
+export function typeAnnotateExpression(node: AstKinds.ExpressionKind, type: string) {
+    const expression: AstTypes.TSAsExpression = {
+        type: "TSAsExpression",
+        expression: node,
+        typeAnnotation: { type: "TSTypeReference", typeName: { type: "Identifier", name: type } },
+    };
+
+    return expression;
+}
+
 export function createLiteral(value: string | null = null) {
     const literal: AstTypes.Literal = {
         type: "Literal",

--- a/packages/ast-manipulation/js/imports.ts
+++ b/packages/ast-manipulation/js/imports.ts
@@ -35,7 +35,7 @@ export function addDefault(ast: AstTypes.Program, importFrom: string, importAs: 
     addImportIfNecessary(ast, expectedImportDeclaration);
 }
 
-export function addNamed(ast: AstTypes.Program, importFrom: string, exportedAsImportAs: Record<string, string>) {
+export function addNamed(ast: AstTypes.Program, importFrom: string, exportedAsImportAs: Record<string, string>, isType = false) {
     const specifiers = Object.entries(exportedAsImportAs).map(([key, value]) => {
         const specifier: AstTypes.ImportSpecifier = {
             type: "ImportSpecifier",
@@ -58,6 +58,7 @@ export function addNamed(ast: AstTypes.Program, importFrom: string, exportedAsIm
             value: importFrom,
         },
         specifiers,
+        importKind: isType ? "type" : undefined,
     };
 
     addImportIfNecessary(ast, expectedImportDeclaration);


### PR DESCRIPTION
closes #348 

Went with the `as Config` route as it was the easiest to implement with relatively low risk of causing side-effects down the line. 