### PR TITLE
feat: preconditions

### DIFF
--- a/adders/bootstrap/config/checks.js
+++ b/adders/bootstrap/config/checks.js
@@ -3,5 +3,18 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
+    preconditions: [
+        {
+            name: "rust installed",
+            run: () => {
+                return { success: true, message: undefined };
+            },
+        },
+        {
+            name: "cargo installed",
+            run: () => {
+                return { success: false, message: undefined };
+            },
+        },
+    ],
 });

--- a/adders/bootstrap/config/checks.js
+++ b/adders/bootstrap/config/checks.js
@@ -3,18 +3,4 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    preconditions: [
-        {
-            name: "rust installed",
-            run: () => {
-                return { success: true, message: undefined };
-            },
-        },
-        {
-            name: "cargo installed",
-            run: () => {
-                return { success: false, message: undefined };
-            },
-        },
-    ],
 });

--- a/adders/bulma/config/checks.js
+++ b/adders/bulma/config/checks.js
@@ -3,5 +3,4 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
 });

--- a/adders/mdsvex/config/checks.js
+++ b/adders/mdsvex/config/checks.js
@@ -3,5 +3,4 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
 });

--- a/adders/routify/config/checks.js
+++ b/adders/routify/config/checks.js
@@ -3,5 +3,4 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
 });

--- a/adders/storybook/config/checks.js
+++ b/adders/storybook/config/checks.js
@@ -3,5 +3,4 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
 });

--- a/adders/tailwindcss/config/checks.js
+++ b/adders/tailwindcss/config/checks.js
@@ -3,5 +3,4 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
 });

--- a/adders/threlte/config/checks.js
+++ b/adders/threlte/config/checks.js
@@ -3,5 +3,4 @@ import { options } from "./options.js";
 
 export const checks = defineAdderChecks({
     options,
-    postInstallation: [],
 });

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -120,20 +120,14 @@ export function defineAdderOptions<Args extends OptionDefinition>(options: Args)
     return options;
 }
 
-export type PreInstallationCheck = {
+export type Precondition = {
     name: string;
-    run: (workingDirectory: string) => boolean;
-};
-
-export type PostInstallationCheck = {
-    name: string;
-    run: (workingDirectory: string) => boolean;
+    run: () => { success: boolean; message: string | undefined };
 };
 
 export type AdderCheckConfig<Args extends OptionDefinition> = {
-    preInstallation?: PreInstallationCheck[];
-    postInstallation: PostInstallationCheck[];
     options: Args;
+    preconditions?: Precondition[];
 };
 
 export function defineAdderChecks<Args extends OptionDefinition>(checks: AdderCheckConfig<Args>) {

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -1,0 +1,68 @@
+import { booleanPrompt } from "../utils/prompts.js";
+import { Precondition } from "./config.js";
+
+export type PreconditionCheckResult = {
+    successfulPreconditions: string[];
+    failedPreconditions: { name: string; message: string }[];
+    autoApplyAdder: boolean;
+};
+
+export function checkPreconditionsStatus(preconditions: Precondition[]) {
+    const status: PreconditionCheckResult = {
+        successfulPreconditions: [],
+        failedPreconditions: [],
+        autoApplyAdder: true,
+    };
+
+    for (const precondition of preconditions) {
+        try {
+            const result = precondition.run();
+
+            if (result.success) {
+                status.successfulPreconditions.push(precondition.name);
+            } else {
+                status.failedPreconditions.push({
+                    name: precondition.name,
+                    message: result.message ?? "No failure message provided",
+                });
+            }
+        } catch (error) {
+            status.failedPreconditions.push({ name: precondition.name, message: "Unexpected failure: " + error });
+        }
+    }
+
+    status.autoApplyAdder = status.failedPreconditions.length == 0;
+
+    return status;
+}
+
+export function printPreconditionResults(preconditionStatus: PreconditionCheckResult) {
+    if (preconditionStatus.successfulPreconditions.length == 0 && preconditionStatus.failedPreconditions.length == 0) {
+        return;
+    }
+
+    const preconditionMessages: { success: boolean; message: string }[] = [];
+    for (const preconditionResult of preconditionStatus.successfulPreconditions) {
+        preconditionMessages.push({ success: true, message: preconditionResult });
+    }
+    for (const preconditionResult of preconditionStatus.failedPreconditions) {
+        preconditionMessages.push({ success: false, message: `${preconditionResult.name} (${preconditionResult.message})` });
+    }
+
+    // sort the elements alphabetically by message
+    preconditionMessages.sort((a, b) => a.message.localeCompare(b.message));
+
+    console.log("Preconditions:");
+    for (const messageData of preconditionMessages) {
+        const symbol = messageData.success ? "✅" : "❌";
+        console.log(`  - ${symbol} ${messageData.message}`);
+    }
+
+    console.log(""); // force a new line after the precondition output
+}
+
+export async function askUserToContinueWithFailedPreconditions() {
+    const result = await booleanPrompt("Preconditions failed. Do you wish to continue?", false);
+
+    if (!result) process.exit();
+}


### PR DESCRIPTION
First part for: #337,
helpful for #338, #363 

This adds preconditions to svelte-add `checks`. Preconditions can be useful to determine if the environment is in a good state to apply the adder. In the future this could contain checks for checking if global tools (rust, cargo, see #338) are installed. While implementing I found out that we should be able to use this feature for detecting if the user currently has a dirty `git` repository and warn him about that (#363).

Opposed to the implementation of `gatekeeping` that `svelte-add@v1` had in place, the user should have the possibility to ignore the preconditions and install the adder if he really likes to.

Sample usage:
```js
export const checks = defineAdderChecks({
    options,
    preconditions: [
        {
            name: "rust installed",
            run: () => {
                return { success: true, message: undefined };
            },
        },
        {
            name: "cargo installed",
            run: () => {
                return { success: false, message: "cargo is not installed" };
            },
        },
    ],
});
```

The sample above results in the following console output:
![image](https://github.com/svelte-add/svelte-add/assets/30698007/39676fce-0f45-420a-981c-8b10d170eab5)

The following things still need to be done
- [ ] make sure the tests work correctly.
- [ ] improve console output. It should be displayed inside the prompts intro and outro, and not separately as it is now.
- [ ] add ability to execute cli commands inside the preconditions
- [ ] exchange the symbols (checkmark / crossmark) with colored console output
