### PR TITLE
feat: display warning if dirty git workspace

### DIFF
--- a/.changeset/smooth-pens-repair.md
+++ b/.changeset/smooth-pens-repair.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+feat: display warning if dirty git workspace

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -129,7 +129,7 @@ async function executePlan<Args extends OptionDefinition>(
 
     // preconditions
     if (!executionPlan.commonCliOptions.skipPreconditions)
-        await validatePreconditions(adderDetails, executingAdder.name, isTesting);
+        await validatePreconditions(adderDetails, executingAdder.name, executionPlan.workingDirectory, isTesting);
 
     // ask the user questions about unselected options
     await requestMissingOptionsFromUser(adderDetails, executionPlan);

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -128,7 +128,8 @@ async function executePlan<Args extends OptionDefinition>(
     adderDetails = adderDetails.filter((x) => userSelectedAdders.includes(x.config.metadata.id));
 
     // preconditions
-    if (!executionPlan.commonCliOptions.skipPreconditions) await validatePreconditions(adderDetails, isTesting);
+    if (!executionPlan.commonCliOptions.skipPreconditions)
+        await validatePreconditions(adderDetails, executingAdder.name, isTesting);
 
     // ask the user questions about unselected options
     await requestMissingOptionsFromUser(adderDetails, executionPlan);

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -1,20 +1,67 @@
-import { config } from "process";
 import { booleanPrompt, endPrompts, messagePrompt } from "../utils/prompts.js";
 import { AdderDetails } from "./execute.js";
 import { OptionDefinition } from "./options.js";
 import pc from "picocolors";
+import { Precondition } from "./config.js";
+import { executeCli } from "../utils/common.js";
+
+function getGlobalPreconditions(executingCli: string): { name: string; preconditions: Precondition[] | undefined } {
+    return {
+        name: executingCli,
+        preconditions: [
+            {
+                name: "clean working directory",
+                run: async () => {
+                    let outputText = "";
+
+                    try {
+                        // If a user has pending git changes the output of the following command will list
+                        // all files that have been added/modified/deleted and thus the output will not be empty.
+                        // In case the output of the command below is an empty text, we can safely assume
+                        // there are no pending changes. If the below command is run outside of a git repository,
+                        // git will exit with a failing exit code, which will trigger the catch statement.
+                        // also see https://remarkablemark.org/blog/2017/10/12/check-git-dirty/#git-status
+                        await executeCli("git", ["status", "--short"], process.cwd(), {
+                            onData: (data, program, resolve) => {
+                                outputText += data;
+                            },
+                        });
+
+                        if (outputText) {
+                            return { success: false, message: "Found modified files" };
+                        }
+
+                        return { success: true, message: undefined };
+                    } catch (error) {
+                        return { success: false, message: "Not a git repository" };
+                    }
+                },
+            },
+        ],
+    };
+}
 
 export async function validatePreconditions<Args extends OptionDefinition>(
     adderDetails: AdderDetails<Args>[],
+    executingCliName: string,
     isTesting: boolean,
 ) {
     const multipleAdders = adderDetails.length > 1;
     let allPreconditionsPassed = true;
     const preconditionLog: string[] = [];
-    for (const { config, checks } of adderDetails) {
-        if (!checks.preconditions) continue;
 
-        for (const precondition of checks.preconditions) {
+    const adderPreconditions = adderDetails.map(({ config, checks }) => {
+        return {
+            name: config.metadata.name,
+            preconditions: checks.preconditions,
+        };
+    });
+    const combinedPreconditions = [getGlobalPreconditions(executingCliName), ...adderPreconditions];
+
+    for (const { name, preconditions } of combinedPreconditions) {
+        if (!preconditions) continue;
+
+        for (const precondition of preconditions) {
             let message;
             let preconditionPassed;
             try {
@@ -33,7 +80,7 @@ export async function validatePreconditions<Args extends OptionDefinition>(
             }
 
             if (multipleAdders) {
-                message = `${config.metadata.name}: ${message}`;
+                message = `${name}: ${message}`;
             }
 
             message = preconditionPassed ? pc.green(message) : pc.yellow(message);

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -5,7 +5,10 @@ import pc from "picocolors";
 import { Precondition } from "./config.js";
 import { executeCli } from "../utils/common.js";
 
-function getGlobalPreconditions(executingCli: string): { name: string; preconditions: Precondition[] | undefined } {
+function getGlobalPreconditions(
+    executingCli: string,
+    workingDirectory: string,
+): { name: string; preconditions: Precondition[] | undefined } {
     return {
         name: executingCli,
         preconditions: [
@@ -21,7 +24,7 @@ function getGlobalPreconditions(executingCli: string): { name: string; precondit
                         // there are no pending changes. If the below command is run outside of a git repository,
                         // git will exit with a failing exit code, which will trigger the catch statement.
                         // also see https://remarkablemark.org/blog/2017/10/12/check-git-dirty/#git-status
-                        await executeCli("git", ["status", "--short"], process.cwd(), {
+                        await executeCli("git", ["status", "--short"], workingDirectory, {
                             onData: (data, program, resolve) => {
                                 outputText += data;
                             },
@@ -44,6 +47,7 @@ function getGlobalPreconditions(executingCli: string): { name: string; precondit
 export async function validatePreconditions<Args extends OptionDefinition>(
     adderDetails: AdderDetails<Args>[],
     executingCliName: string,
+    workingDirectory: string,
     isTesting: boolean,
 ) {
     const multipleAdders = adderDetails.length > 1;
@@ -56,7 +60,7 @@ export async function validatePreconditions<Args extends OptionDefinition>(
             preconditions: checks.preconditions,
         };
     });
-    const combinedPreconditions = [getGlobalPreconditions(executingCliName), ...adderPreconditions];
+    const combinedPreconditions = [getGlobalPreconditions(executingCliName, workingDirectory), ...adderPreconditions];
 
     for (const { name, preconditions } of combinedPreconditions) {
         if (!preconditions) continue;

--- a/packages/core/utils/common.ts
+++ b/packages/core/utils/common.ts
@@ -36,7 +36,7 @@ export async function executeCli(
     commandArgs: string[],
     cwd: string,
     options?: {
-        onData?: (data: string, program: ChildProcess, resolve: (value: any) => any) => void;
+        onData?: (data: string, program: ChildProcess, resolve: (value?: any) => any) => void;
         stdio?: "pipe" | "inherit";
         env?: Record<string, string>;
     },


### PR DESCRIPTION
Closes #363

Adds a new global precondition checking if the working directory is a git repository and contians uncomitted changes. If that's the case the precondition will fail.
As with all other preconditions, this check can be disabled with `--skip-preconditions`