### PR TITLE
feat: add `--default` flag

### DIFF
--- a/.changeset/curly-peaches-do.md
+++ b/.changeset/curly-peaches-do.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+feat: added the shorthand `--default` flag to install the default adder options

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -74,7 +74,7 @@ export async function executeAdders<Args extends OptionDefinition>(
 
     let workingDirectory: string | null;
     if (isTesting) workingDirectory = remoteControlOptions.workingDirectory;
-    else workingDirectory = await determineWorkingDirectory(commonCliOptions.path);
+    else workingDirectory = determineWorkingDirectory(commonCliOptions.path);
     workingDirectory = await detectSvelteDirectory(workingDirectory);
     const createProject = workingDirectory == null;
     if (!workingDirectory) workingDirectory = process.cwd();
@@ -130,6 +130,16 @@ async function executePlan<Args extends OptionDefinition>(
     // preconditions
     if (!executionPlan.commonCliOptions.skipPreconditions)
         await validatePreconditions(adderDetails, executingAdder.name, executionPlan.workingDirectory, isTesting);
+
+    // applies the default option value to adder's cli options
+    if (executionPlan.commonCliOptions.default) {
+        for (const adder of adderDetails) {
+            const adderId = adder.config.metadata.id;
+            for (const [option, value] of Object.entries(adder.config.options)) {
+                executionPlan.cliOptionsByAdderId[adderId][option] = value.default;
+            }
+        }
+    }
 
     // ask the user questions about unselected options
     await requestMissingOptionsFromUser(adderDetails, executionPlan);

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -131,12 +131,12 @@ async function executePlan<Args extends OptionDefinition>(
     if (!executionPlan.commonCliOptions.skipPreconditions)
         await validatePreconditions(adderDetails, executingAdder.name, executionPlan.workingDirectory, isTesting);
 
-    // applies the default option value to adder's cli options
+    // applies the default option value to missing adder's cli options
     if (executionPlan.commonCliOptions.default) {
         for (const adder of adderDetails) {
             const adderId = adder.config.metadata.id;
             for (const [option, value] of Object.entries(adder.config.options)) {
-                executionPlan.cliOptionsByAdderId[adderId][option] = value.default;
+                executionPlan.cliOptionsByAdderId[adderId][option] ??= value.default;
             }
         }
     }

--- a/packages/core/adder/options.ts
+++ b/packages/core/adder/options.ts
@@ -63,7 +63,7 @@ export const availableCliOptions: AvailableCliOptions = {
         processedCliArg: "default",
         type: "boolean",
         default: false,
-        description: "Installs default adder options",
+        description: "Installs default adder options for unspecified options",
         allowShorthand: true,
     },
     path: {

--- a/packages/core/adder/options.ts
+++ b/packages/core/adder/options.ts
@@ -37,8 +37,9 @@ export type OptionValues<Args extends OptionDefinition> = {
             : never;
 };
 
-export type AvailableCliOptionKeys = "path" | "skipPreconditions" | "skipInstall";
+export type AvailableCliOptionKeys = keyof AvailableCliOptionKeyTypes;
 export type AvailableCliOptionKeyTypes = {
+    default: boolean;
     path: string;
     skipPreconditions: boolean;
     skipInstall: boolean;
@@ -57,6 +58,14 @@ export type AvailableCliOption = {
 export type AvailableCliOptions = Record<AvailableCliOptionKeys, AvailableCliOption>;
 
 export const availableCliOptions: AvailableCliOptions = {
+    default: {
+        cliArg: "default",
+        processedCliArg: "default",
+        type: "boolean",
+        default: false,
+        description: "Installs default adder options",
+        allowShorthand: true,
+    },
     path: {
         cliArg: "path",
         processedCliArg: "path",
@@ -168,6 +177,7 @@ export function ensureCorrectOptionTypes<Args extends OptionDefinition>(
 
 export function extractCommonCliOptions(cliOptions: CliOptionValues) {
     const commonOptions: AvailableCliOptionValues = {
+        default: cliOptions[availableCliOptions.default.processedCliArg],
         path: cliOptions[availableCliOptions.path.processedCliArg],
         skipInstall: cliOptions[availableCliOptions.skipInstall.processedCliArg],
         skipPreconditions: cliOptions[availableCliOptions.skipPreconditions.processedCliArg],

--- a/packages/core/utils/dependencies.ts
+++ b/packages/core/utils/dependencies.ts
@@ -30,7 +30,6 @@ export async function suggestInstallingDependencies(workingDirectory: string) {
     }
 
     if (!selectedPm || !packageManagers[selectedPm]) {
-        console.log("Skipped installing dependencies");
         return;
     }
 

--- a/packages/dev-utils/utils/generate-readme.ts
+++ b/packages/dev-utils/utils/generate-readme.ts
@@ -99,7 +99,7 @@ function generateCommonOptions(adderNpx: string) {
         markdown += `\n- \`${value.cliArg}\` (default: ${value.default}) - ${value.description}`;
     }
 
-    const firstOptionValue = options[0];
+    const firstOptionValue = options.find((option) => option.cliArg === "path")!;
 
     markdown += `\n\n
 Option syntax


### PR DESCRIPTION
Closes #350

This PR adds the `--default` flag as a shorthand to install the default adder options for **missing options**.

For example, say that we have 2 tailwind options `typography` and `forms` (assume both have their defaults set to `false`). If we were to run the command like so:
```bash
@svelte-add/tailwindcss --default --typography
```
the `typography` plugin will still be added as it was manually specified, but the `forms` plugin will not.