### PR TITLE
feat: post-conditions

### DIFF
--- a/.changeset/mighty-knives-count.md
+++ b/.changeset/mighty-knives-count.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+add postconditions

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "typescript.tsserver.experimental.enableProjectDiagnostics": true,
-    "cSpell.words": ["ecma", "popperjs", "Svex", "threlte"]
+    "cSpell.words": ["ecma", "popperjs", "postcondition", "Postcondition", "postconditions", "Svex", "threlte"]
 }

--- a/adders/bootstrap/config/checks.js
+++ b/adders/bootstrap/config/checks.js
@@ -9,7 +9,7 @@ export const checks = defineAdderChecks({
             run: async ({ fileExists, fileContains }) => {
                 const filePath = `src/variables.scss`;
                 await fileExists(filePath);
-                await fileContains(filePath, "testasd");
+                await fileContains(filePath, "$background: lightgrey;");
             },
         },
     ],

--- a/adders/bootstrap/config/checks.js
+++ b/adders/bootstrap/config/checks.js
@@ -3,4 +3,14 @@ import { options } from "./options";
 
 export const checks = defineAdderChecks({
     options,
+    postconditions: [
+        {
+            name: "scss setup",
+            run: async ({ fileExists, fileContains }) => {
+                const filePath = `src/variables.scss`;
+                await fileExists(filePath);
+                await fileContains(filePath, "testasd");
+            },
+        },
+    ],
 });

--- a/adders/bootstrap/config/checks.js
+++ b/adders/bootstrap/config/checks.js
@@ -7,9 +7,11 @@ export const checks = defineAdderChecks({
         {
             name: "scss setup",
             run: async ({ fileExists, fileContains }) => {
-                const filePath = `src/variables.scss`;
-                await fileExists(filePath);
-                await fileContains(filePath, "$background: lightgrey;");
+                if (options.useSass) {
+                    const filePath = `src/variables.scss`;
+                    await fileExists(filePath);
+                    await fileContains(filePath, "$background: lightgrey;");
+                }
             },
         },
     ],

--- a/adders/bootstrap/config/checks.js
+++ b/adders/bootstrap/config/checks.js
@@ -7,11 +7,11 @@ export const checks = defineAdderChecks({
         {
             name: "scss setup",
             run: async ({ fileExists, fileContains }) => {
-                if (options.useSass) {
-                    const filePath = `src/variables.scss`;
-                    await fileExists(filePath);
-                    await fileContains(filePath, "$background: lightgrey;");
-                }
+                // if (options.useSass) {
+                //     const filePath = `src/variables.scss`;
+                //     await fileExists(filePath);
+                //     await fileContains(filePath, "$background: lightgrey;");
+                // }
             },
         },
     ],

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -5,6 +5,7 @@ import { CategoryInfo } from "./categories.js";
 import { OptionDefinition, OptionValues, Question } from "./options.js";
 import { FileTypes } from "../files/processors.js";
 import { Workspace } from "../utils/workspace.js";
+import { Postcondition } from "./postconditions.js";
 
 export { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor };
 
@@ -130,6 +131,7 @@ export type Precondition = {
 export type AdderCheckConfig<Args extends OptionDefinition> = {
     options: Args;
     preconditions?: Precondition[];
+    postconditions?: Postcondition<Args>[];
 };
 
 export function defineAdderChecks<Args extends OptionDefinition>(checks: AdderCheckConfig<Args>) {

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -18,14 +18,15 @@ import {
     AvailableCliOptionValues,
     requestMissingOptionsFromUser,
 } from "./options.js";
-import type { AdderCheckConfig, AdderConfig, ExternalAdderConfig, InlineAdderConfig, Precondition } from "./config.js";
+import type { AdderCheckConfig, AdderConfig, ExternalAdderConfig, InlineAdderConfig } from "./config.js";
 import type { RemoteControlOptions } from "./remoteControl.js";
 import { suggestInstallingDependencies } from "../utils/dependencies.js";
 import { serializeJson } from "@svelte-add/ast-tooling";
 import { validatePreconditions } from "./preconditions.js";
-import { PromptOption, endPrompts, multiSelectPrompt, startPrompts, textPrompt } from "../utils/prompts.js";
+import { PromptOption, endPrompts, messagePrompt, multiSelectPrompt, startPrompts, textPrompt } from "../utils/prompts.js";
 import { categories } from "./categories.js";
-import { booleanPrompt, messagePrompt } from "../utils/prompts.js";
+import { checkPostconditions } from "./postconditions.js";
+import pc from "picocolors";
 
 export type AdderDetails<Args extends OptionDefinition> = {
     config: AdderConfig<Args>;
@@ -145,10 +146,11 @@ async function executePlan<Args extends OptionDefinition>(
     await requestMissingOptionsFromUser(adderDetails, executionPlan);
 
     // apply the adders
-    for (const { config } of adderDetails) {
+    const unmetPostconditions: string[] = [];
+    for (const { config, checks } of adderDetails) {
         const adderId = config.metadata.id;
 
-        const workspace = createEmptyWorkspace();
+        const workspace = createEmptyWorkspace<Args>();
         await populateWorkspaceDetails(workspace, executionPlan.workingDirectory);
         if (executionPlan.cliOptionsByAdderId) {
             for (const [key, value] of Object.entries(executionPlan.cliOptionsByAdderId[adderId])) {
@@ -165,6 +167,15 @@ async function executePlan<Args extends OptionDefinition>(
         } else {
             throw new Error(`Unknown integration type`);
         }
+
+        const unmetAdderPostconditions = await checkPostconditions(config, checks, workspace, adderDetails.length > 1);
+        unmetPostconditions.push(...unmetAdderPostconditions);
+    }
+
+    if (isTesting && unmetPostconditions.length > 0) {
+        throw new Error("Postconditions not met: " + unmetPostconditions.join(" / "));
+    } else if (unmetPostconditions.length > 0) {
+        messagePrompt("Postconditions not met", unmetPostconditions.map((x) => pc.yellow(`- ${x}`)).join("\n"));
     }
 
     if (!remoteControlled && !executionPlan.commonCliOptions.skipInstall)

--- a/packages/core/adder/postconditions.ts
+++ b/packages/core/adder/postconditions.ts
@@ -1,0 +1,59 @@
+import { Workspace } from "../utils/workspace";
+import { AdderCheckConfig, AdderConfig } from "./config";
+import { OptionDefinition } from "./options";
+import { fileExistsWorkspace, readFile } from "../files/utils";
+
+export type PreconditionParameters<Args extends OptionDefinition> = {
+    workspace: Workspace<Args>;
+    fileExists: (path: string) => Promise<void>;
+    fileContains: (path: string, expectedContent: string) => Promise<void>;
+};
+export type Postcondition<Args extends OptionDefinition> = {
+    name: string;
+    run: (params: PreconditionParameters<Args>) => Promise<void>;
+};
+
+export async function checkPostconditions<Args extends OptionDefinition>(
+    config: AdderConfig<Args>,
+    checks: AdderCheckConfig<Args>,
+    workspace: Workspace<Args>,
+    multipleAdders: boolean,
+) {
+    const postconditions = checks.postconditions ?? [];
+    const unmetPostconditions: string[] = [];
+
+    for (const postcondition of postconditions) {
+        try {
+            await postcondition.run({
+                workspace,
+                fileExists: (path) => fileExists(path, workspace),
+                fileContains: (path, expectedContent) => fileContains(path, workspace, expectedContent),
+            });
+        } catch (error) {
+            const typedError = error as Error;
+            const message = `${postcondition.name} (${typedError.message})`;
+            unmetPostconditions.push(`${multipleAdders ? config.metadata.id + ": " : ""}${message}`);
+        }
+    }
+
+    return unmetPostconditions;
+}
+
+async function fileExists<Args extends OptionDefinition>(path: string, workspace: Workspace<Args>) {
+    if (await fileExistsWorkspace(workspace, path)) return;
+
+    throw new Error(`File "${path}" does not exists`);
+}
+
+async function fileContains<Args extends OptionDefinition>(
+    path: string,
+    workspace: Workspace<Args>,
+    expectedContent: string,
+): Promise<void> {
+    await fileExists(path, workspace);
+
+    const content = await readFile(workspace, path);
+    if (content && content.includes(expectedContent)) return;
+
+    throw new Error(`File "${path}" does not contain "${expectedContent}"`);
+}


### PR DESCRIPTION
Closes #337 (preconditions already implemented by #368) 

Usage:
```js
export const checks = defineAdderChecks({
    options,
    postconditions: [
        {
            name: "scss setup",
            run: async ({ fileExists, fileContains }) => {
                if (options.useSass) {
                    const filePath = `src/variables.scss`;
                    await fileExists(filePath);
                    await fileContains(filePath, "$background: lightgrey;");
                }
            },
        },
    ],
});
```

Will be helpful for all adders that we cannot check with integration testing, like #338, #339 , etc.

This is currently **not** implemented for any adder, as all adders are currently testable by integration testing. Future adders will use this feature.

Console output looks like this:
![image](https://github.com/svelte-add/svelte-add/assets/30698007/1f7b45b3-63eb-4e71-8c8c-1f8dbafd25d4)
