### PR TITLE
fix: move storybook from styling category to tools category

### DIFF
--- a/.changeset/silent-students-poke.md
+++ b/.changeset/silent-students-poke.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/storybook": patch
+---
+
+fix: move storybook from styling category to tools category

--- a/adders/storybook/config/adder.js
+++ b/adders/storybook/config/adder.js
@@ -7,7 +7,7 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "Storybook",
         description: "Build UIs without the grunt work",
-        category: categories.styling,
+        category: categories.tools,
         environments: { kit: true, svelte: true },
         website: {
             logo: "./storybook.svg",


### PR DESCRIPTION
Storybook feels out-of-place in the styling category to me since it's not a CSS framework like the others and does so much more than just help you with styling. 

From their homepage:
Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation.