### PR TITLE
fix: avoid adding adders to unsupported project types

### DIFF
--- a/.changeset/slimy-singers-shave.md
+++ b/.changeset/slimy-singers-shave.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: avoid adding adders to unsupported project types

--- a/adders/routify/config/tests.js
+++ b/adders/routify/config/tests.js
@@ -10,13 +10,13 @@ export const tests = defineAdderTests({
             name: "check page switch",
             run: async ({ elementExists, click, expectUrlPath }) => {
                 await elementExists(".routify-demo");
-                await expectUrlPath("/");
+                expectUrlPath("/");
 
                 await click(".routify-demo .demo", "/demo");
-                await expectUrlPath("/demo");
+                expectUrlPath("/demo");
 
                 await click(".routify-demo .index", "/");
-                await expectUrlPath("/");
+                expectUrlPath("/");
             },
         },
     ],

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -97,7 +97,7 @@ export type Tests = {
     expectProperty: (selector: string, property: string, expectedValue: string) => Promise<void>;
     elementExists: (selector: string) => Promise<void>;
     click: (selector: string, path?: string) => Promise<void>;
-    expectUrlPath: (path: string) => Promise<void>;
+    expectUrlPath: (path: string) => void;
 };
 
 export type TestDefinition<Args extends OptionDefinition> = {
@@ -123,9 +123,11 @@ export function defineAdderOptions<const Args extends OptionDefinition>(options:
     return options;
 }
 
+type MaybePromise<T> = Promise<T> | T;
+
 export type Precondition = {
     name: string;
-    run: () => Promise<{ success: boolean; message: string | undefined }>;
+    run: () => MaybePromise<{ success: boolean; message: string | undefined }>;
 };
 
 export type AdderCheckConfig<Args extends OptionDefinition> = {

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { commonFilePaths, format, writeFile } from "../files/utils.js";
-import { ProjectType, createProject, detectSvelteDirectory } from "../utils/create-project.js";
+import { type ProjectType, createProject, detectSvelteDirectory } from "../utils/create-project.js";
 import { createOrUpdateFiles } from "../files/processors.js";
 import { Package, executeCli, getPackageJson, groupBy } from "../utils/common.js";
 import {

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -105,7 +105,9 @@ async function executePlan<Args extends OptionDefinition>(
     // create project if required
     if (executionPlan.createProject) {
         const cwd = executionPlan.commonCliOptions.path ?? executionPlan.workingDirectory;
-        const { projectCreated, directory } = await createProject(cwd);
+        const supportKit = adderDetails.reduce((value, x) => value || x.config.metadata.environments.kit, false);
+        const supportSvelte = adderDetails.reduce((value, x) => value || x.config.metadata.environments.svelte, false);
+        const { projectCreated, directory } = await createProject(cwd, supportKit, supportSvelte);
         if (!projectCreated) return;
         executionPlan.workingDirectory = directory;
     }

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -138,7 +138,7 @@ async function executePlan<Args extends OptionDefinition>(
 
     // preconditions
     if (!executionPlan.commonCliOptions.skipPreconditions)
-        await validatePreconditions(adderDetails, executingAdder.name, executionPlan.workingDirectory, isTesting);
+        await validatePreconditions(adderDetails, executingAdder.name, executionPlan.workingDirectory, isTesting, projectType);
 
     // applies the default option value to missing adder's cli options
     if (executionPlan.commonCliOptions.default) {

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -45,8 +45,7 @@ function getGlobalPreconditions<Args extends OptionDefinition>(
             },
             {
                 name: "supported environments",
-                // eslint-disable-next-line @typescript-eslint/require-await
-                run: async () => {
+                run: () => {
                     const addersForInvalidEnvironment = adderDetails.filter((x) => {
                         const supportedEnvironments = x.config.metadata.environments;
                         if (projectType == "kit" && !supportedEnvironments.kit) return true;
@@ -60,7 +59,7 @@ function getGlobalPreconditions<Args extends OptionDefinition>(
                     }
 
                     const messages = addersForInvalidEnvironment.map(
-                        (adder) => `"${adder.config.metadata.name}" does not support "${projectType}"`,
+                        (adder) => `"${adder.config.metadata.name}" does not support "${projectType.toString()}"`,
                     );
                     return { success: false, message: messages.join(" / ") };
                 },

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -59,10 +59,9 @@ function getGlobalPreconditions<Args extends OptionDefinition>(
                         return { success: true, message: undefined };
                     }
 
-                    const messages: string[] = [];
-                    for (const adder of addersForInvalidEnvironment) {
-                        messages.push(`"${adder.config.metadata.name}" does not support "${projectType}"`);
-                    }
+                    const messages = addersForInvalidEnvironment.map(
+                        (adder) => `"${adder.config.metadata.name}" does not support "${projectType}"`,
+                    );
                     return { success: false, message: messages.join(" / ") };
                 },
             },

--- a/packages/core/internal.ts
+++ b/packages/core/internal.ts
@@ -2,7 +2,6 @@ import * as remoteControl from "./adder/remoteControl.js";
 import { executeAdder, executeAdders, determineWorkingDirectory } from "./adder/execute.js";
 import { createOrUpdateFiles } from "./files/processors.js";
 import { createEmptyWorkspace, populateWorkspaceDetails } from "./utils/workspace.js";
-import { detectOrCreateProject } from "./utils/create-project.js";
 import { PromptOption, endPrompts, multiSelectPrompt, textPrompt, startPrompts } from "./utils/prompts.js";
 import { suggestInstallingDependencies } from "./utils/dependencies.js";
 import { groupBy } from "./utils/common.js";
@@ -16,7 +15,6 @@ export {
     executeAdders,
     populateWorkspaceDetails,
     determineWorkingDirectory,
-    detectOrCreateProject,
     PromptOption,
     endPrompts,
     multiSelectPrompt,

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { PromptOption, booleanPrompt, selectPrompt, textPrompt } from "./prompts.js";
+import { commonFilePaths, directoryExists, fileExists } from "../files/utils.js";
 import { type PromptOption, booleanPrompt, selectPrompt, textPrompt, endPrompts } from "./prompts.js";
 import { executeCli, getPackageJson } from "./common.js";
 import { createEmptyWorkspace } from "./workspace.js";

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { PromptOption, booleanPrompt, selectPrompt, textPrompt } from "./prompts.js";
-import { commonFilePaths, directoryExists, fileExists } from "../files/utils.js";
+import { type PromptOption, booleanPrompt, selectPrompt, textPrompt, endPrompts } from "./prompts.js";
 import { executeCli, getPackageJson } from "./common.js";
 import { createEmptyWorkspace } from "./workspace.js";
 import { spinner } from "@clack/prompts";
@@ -42,7 +42,7 @@ export async function detectSvelteDirectory(directoryPath: string): Promise<stri
 export async function createProject(cwd: string, supportKit: boolean, supportSvelte: boolean) {
     const createNewProject = await booleanPrompt("Create new Project?", true);
     if (!createNewProject) {
-        console.log("New project should not be created. Exiting.");
+        endPrompts("Exiting.");
         process.exit(0);
     }
 
@@ -63,7 +63,7 @@ export async function createProject(cwd: string, supportKit: boolean, supportSve
     let projectType: string;
 
     if (availableProjectTypes.length == 0) throw new Error("Failed to identify possible project types");
-    else if (availableProjectTypes.length == 1) projectType = availableProjectTypes[0].value;
+    if (availableProjectTypes.length == 1) projectType = availableProjectTypes[0].value;
     else projectType = await selectPrompt("Which project type do you want to create?", "kit", availableProjectTypes);
 
     let language = "js";

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { booleanPrompt, selectPrompt, textPrompt } from "./prompts.js";
+import { PromptOption, booleanPrompt, selectPrompt, textPrompt } from "./prompts.js";
 import { commonFilePaths, directoryExists, fileExists } from "../files/utils.js";
 import { executeCli, getPackageJson } from "./common.js";
 import { createEmptyWorkspace } from "./workspace.js";
@@ -39,7 +39,7 @@ export async function detectSvelteDirectory(directoryPath: string): Promise<stri
     return null;
 }
 
-export async function createProject(cwd: string) {
+export async function createProject(cwd: string, supportKit: boolean, supportSvelte: boolean) {
     const createNewProject = await booleanPrompt("Create new Project?", true);
     if (!createNewProject) {
         console.log("New project should not be created. Exiting.");
@@ -56,10 +56,15 @@ export async function createProject(cwd: string) {
         directory = relativePath;
     }
 
-    const projectType = await selectPrompt("Which project type do you want to create?", "kit", [
-        { label: "SvelteKit", value: "kit" },
-        { label: "Svelte", value: "svelte" },
-    ]);
+    const availableProjectTypes: PromptOption<string>[] = [];
+    if (supportKit) availableProjectTypes.push({ label: "SvelteKit", value: "kit" });
+    if (supportSvelte) availableProjectTypes.push({ label: "Svelte", value: "svelte" });
+
+    let projectType: string;
+
+    if (availableProjectTypes.length == 0) throw new Error("Failed to identify possible project types");
+    else if (availableProjectTypes.length == 1) projectType = availableProjectTypes[0].value;
+    else projectType = await selectPrompt("Which project type do you want to create?", "kit", availableProjectTypes);
 
     let language = "js";
     if (projectType == "svelte") {

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -5,24 +5,7 @@ import { executeCli, getPackageJson } from "./common.js";
 import { createEmptyWorkspace } from "./workspace.js";
 import { spinner } from "@clack/prompts";
 
-export async function detectOrCreateProject(cwd: string) {
-    let workingDirectory = await detectSvelteDirectory(cwd);
-    if (!workingDirectory) {
-        console.log("Please create a new project first");
-
-        const { projectCreated, directory } = await createProject(cwd);
-
-        if (!projectCreated) {
-            console.log("Template initializer failed, please see output above.");
-            process.exit(0);
-        }
-
-        console.clear();
-        workingDirectory = directory;
-    }
-
-    return workingDirectory;
-}
+export type ProjectType = "svelte" | "kit";
 
 export async function detectSvelteDirectory(directoryPath: string): Promise<string | null> {
     if (!directoryPath) return null;

--- a/packages/testing-library/utils/test.ts
+++ b/packages/testing-library/utils/test.ts
@@ -13,8 +13,7 @@ export async function runTests(page: Page, adder: AdderWithoutExplicitArgs, opti
         click: async (selector, path) => {
             await click(page, selector, path);
         },
-        // eslint-disable-next-line @typescript-eslint/require-await
-        expectUrlPath: async (path) => {
+        expectUrlPath: (path) => {
             expectUrlPath(page, path);
         },
     };


### PR DESCRIPTION
Overall, this PR tries to avoid that users get the possibility to apply an adder for an unsupported environment. Each adder can define the supported environments in its adder config.

Closes #394 
Closes #387

There are a few cases that we need to consider in order to ensure this requirement.

```sh
npx svelte-add
```
This will detect a project in the cwd or ask the user to create a project. After that it will display all categories with the appropriate adders. Up to this point a project has been detected for sure, so we can just hide the invalid combinations (i.e. routify, if kit project)

```sh
npx @svelte-add/routify
```
This will detect a project in the cwd or ask the user to create a project. If creating a project, the user is unable to create a kit project, as that option is hidden, and the svelte project template is automatically selected.
In case this was called on an existing project there is a new precondition that will fail, indicating that routify is not supported in kit projects.

```sh
npx svelte-add --adder bulma routify
```
This will detect a project in the cwd or ask the user to create a project. If creating a project, we cannot hide either the kit or svelte templates as both templates are valid for at least one adder. Both options remain available for the user.
In case this was called on an existing project, or on a new project there is a new precondition that will fail, indicating that routify is not supported in kit projects.

---

I hope all of this kinda makes sense. I tried to find a more unified approach but all of these approaches had problems with the user flow. This is the best, un-obtrusive solution I came up with.

But I'm happy to implement a better solution is someone can come up with one.