### PR TITLE
feat: display next steps after running the adders

### DIFF
--- a/.changeset/gorgeous-crabs-camp.md
+++ b/.changeset/gorgeous-crabs-camp.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/drizzle": minor
+---
+
+feat: display next steps after running the drizzle

--- a/.changeset/moody-pumas-do.md
+++ b/.changeset/moody-pumas-do.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+feat: display next steps after running the adders

--- a/adders/bootstrap/config/adder.ts
+++ b/adders/bootstrap/config/adder.ts
@@ -130,13 +130,6 @@ export const adder = defineAdderConfig({
             },
         },
     ],
-    nextSteps: ({ options, cwd, colors, docs }) => {
-        var steps = ["this is a test next step other", "cwd: " + cwd, "select sass: " + colors.green(options.useSass.toString())];
-
-        if (docs) steps.push("docs: " + colors.cyan(docs));
-
-        return steps;
-    },
 });
 
 /**

--- a/adders/bootstrap/config/adder.ts
+++ b/adders/bootstrap/config/adder.ts
@@ -130,8 +130,12 @@ export const adder = defineAdderConfig({
             },
         },
     ],
-    nextSteps: () => {
-        return ["this is a test next step other", "this is another step"];
+    nextSteps: ({ options, cwd, colors, docs }) => {
+        var steps = ["this is a test next step other", "cwd: " + cwd, "select sass: " + colors.green(options.useSass.toString())];
+
+        if (docs) steps.push("docs: " + colors.cyan(docs));
+
+        return steps;
     },
 });
 

--- a/adders/bootstrap/config/adder.ts
+++ b/adders/bootstrap/config/adder.ts
@@ -131,7 +131,7 @@ export const adder = defineAdderConfig({
         },
     ],
     nextSteps: () => {
-        return "this is a test next step";
+        return ["this is a test next step other", "this is another step"];
     },
 });
 

--- a/adders/bootstrap/config/adder.ts
+++ b/adders/bootstrap/config/adder.ts
@@ -130,6 +130,9 @@ export const adder = defineAdderConfig({
             },
         },
     ],
+    nextSteps: () => {
+        return "this is a test next step";
+    },
 });
 
 /**

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -339,7 +339,7 @@ export const adder = defineAdderConfig({
         },
     ],
     nextSteps: () => {
-        const steps = ["You will need to set the DATABASE_URL in your production environment"];
+        const steps = ["You will need to set DATABASE_URL in your production environment"];
 
         return steps;
     },

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -338,6 +338,11 @@ export const adder = defineAdderConfig({
             },
         },
     ],
+    nextSteps: () => {
+        const steps = ["You will need to set the DATABASE_URL in your production environment"];
+
+        return steps;
+    },
 });
 
 function addEnvVar(content: string, key: string, value: string) {

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -6,6 +6,7 @@ import type { OptionDefinition, OptionValues, Question } from "./options.js";
 import type { FileTypes } from "../files/processors.js";
 import type { Workspace } from "../utils/workspace.js";
 import type { Postcondition } from "./postconditions.js";
+import { Colors } from "picocolors/types.js";
 
 export type { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor };
 
@@ -51,7 +52,7 @@ export type InlineAdderConfig<Args extends OptionDefinition> = BaseAdderConfig<A
     integrationType: "inline";
     packages: PackageDefinition<Args>[];
     files: FileTypes<Args>[];
-    nextSteps?: () => string[];
+    nextSteps?: (data: { options: OptionValues<Args>; cwd: string; colors: Colors; docs: string | undefined }) => string[];
     installHook?: (workspace: Workspace<Args>) => Promise<void>;
     uninstallHook?: (workspace: Workspace<Args>) => Promise<void>;
 };

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -6,7 +6,7 @@ import type { OptionDefinition, OptionValues, Question } from "./options.js";
 import type { FileTypes } from "../files/processors.js";
 import type { Workspace } from "../utils/workspace.js";
 import type { Postcondition } from "./postconditions.js";
-import { Colors } from "picocolors/types.js";
+import type { Colors } from "picocolors/types.js";
 
 export type { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor };
 

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -51,7 +51,7 @@ export type InlineAdderConfig<Args extends OptionDefinition> = BaseAdderConfig<A
     integrationType: "inline";
     packages: PackageDefinition<Args>[];
     files: FileTypes<Args>[];
-    nextSteps?: () => string;
+    nextSteps?: () => string[];
     installHook?: (workspace: Workspace<Args>) => Promise<void>;
     uninstallHook?: (workspace: Workspace<Args>) => Promise<void>;
 };

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -51,6 +51,7 @@ export type InlineAdderConfig<Args extends OptionDefinition> = BaseAdderConfig<A
     integrationType: "inline";
     packages: PackageDefinition<Args>[];
     files: FileTypes<Args>[];
+    nextSteps?: () => string;
     installHook?: (workspace: Workspace<Args>) => Promise<void>;
     uninstallHook?: (workspace: Workspace<Args>) => Promise<void>;
 };

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -196,7 +196,7 @@ async function executePlan<Args extends OptionDefinition>(
         await suggestInstallingDependencies(executionPlan.workingDirectory);
 
     if (!isTesting) {
-        displayNextSteps(adderDetails, isApplyingMultipleAdders);
+        displayNextSteps(adderDetails, isApplyingMultipleAdders, executionPlan);
         endPrompts("You're all set!");
     }
 }

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -27,6 +27,7 @@ import { validatePreconditions } from "./preconditions.js";
 import { endPrompts, startPrompts, groupedMultiSelectPrompt } from "../utils/prompts.js";
 import { type CategoryKeys, categories } from "./categories.js";
 import { checkPostconditions, printUnmetPostconditions } from "./postconditions.js";
+import { displayNextSteps } from "./nextSteps.js";
 
 export type AdderDetails<Args extends OptionDefinition> = {
     config: AdderConfig<Args>;
@@ -193,7 +194,10 @@ async function executePlan<Args extends OptionDefinition>(
     if (!remoteControlled && !executionPlan.commonCliOptions.skipInstall)
         await suggestInstallingDependencies(executionPlan.workingDirectory);
 
-    if (!isTesting) endPrompts("You're all set!");
+    if (!isTesting) {
+        displayNextSteps(adderDetails, isExecutingMultipleAdders);
+        endPrompts("You're all set!");
+    }
 }
 type AdderOption = { value: string; label: string; hint: string };
 async function askForAddersToApply<Args extends OptionDefinition>(

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -100,7 +100,7 @@ async function executePlan<Args extends OptionDefinition>(
 ) {
     const remoteControlled = remoteControlOptions !== undefined;
     const isTesting = remoteControlled && remoteControlOptions.isTesting;
-    const isExecutingMultipleAdders = adderDetails.length > 1;
+    const isRunningCli = adderDetails.length > 1;
 
     if (!isTesting) {
         console.log(pc.gray(`${executingAdder.name} version ${executingAdder.version}\n`));
@@ -123,14 +123,15 @@ async function executePlan<Args extends OptionDefinition>(
 
     // select appropriate adders
     let userSelectedAdders = executionPlan.commonCliOptions.adders ?? [];
-    if (userSelectedAdders.length == 0 && isExecutingMultipleAdders) {
+    if (userSelectedAdders.length == 0 && isRunningCli) {
         // if the user has not selected any adders via the cli and we are currently executing for more than one adder
         // the user should have the possibility to select the adders he want's to add.
         userSelectedAdders = await askForAddersToApply(adderDetails, projectType);
-    } else if (userSelectedAdders.length == 0 && !isExecutingMultipleAdders) {
+    } else if (userSelectedAdders.length == 0 && !isRunningCli) {
         // if we are executing only one adder, then we can safely assume that this adder should be added
         userSelectedAdders = [adderDetails[0].config.metadata.id];
     }
+    const isApplyingMultipleAdders = userSelectedAdders.length > 1;
 
     // remove unselected adder data
     const addersToRemove = adderDetails.filter((x) => !userSelectedAdders.includes(x.config.metadata.id));
@@ -181,7 +182,7 @@ async function executePlan<Args extends OptionDefinition>(
             throw new Error(`Unknown integration type`);
         }
 
-        const unmetAdderPostconditions = await checkPostconditions(config, checks, adderWorkspace, isExecutingMultipleAdders);
+        const unmetAdderPostconditions = await checkPostconditions(config, checks, adderWorkspace, isApplyingMultipleAdders);
         unmetPostconditions.push(...unmetAdderPostconditions);
     }
 
@@ -195,7 +196,7 @@ async function executePlan<Args extends OptionDefinition>(
         await suggestInstallingDependencies(executionPlan.workingDirectory);
 
     if (!isTesting) {
-        displayNextSteps(adderDetails, isExecutingMultipleAdders);
+        displayNextSteps(adderDetails, isApplyingMultipleAdders);
         endPrompts("You're all set!");
     }
 }

--- a/packages/core/adder/nextSteps.ts
+++ b/packages/core/adder/nextSteps.ts
@@ -1,0 +1,29 @@
+import { messagePrompt } from "../utils/prompts";
+import { InlineAdderConfig } from "./config";
+import { AdderDetails } from "./execute";
+import { OptionDefinition } from "./options";
+import { green } from "picocolors";
+
+export function displayNextSteps<Args extends OptionDefinition>(adderDetails: AdderDetails<Args>[], multipleAdders: boolean) {
+    const allAddersMessage = adderDetails
+        .filter((x) => x.config.integrationType == "inline")
+        .map((x) => x.config as InlineAdderConfig<Args>)
+        .map((x) => {
+            const metadata = x.metadata;
+            let adderMessage = "";
+            if (multipleAdders) {
+                adderMessage = `${green(metadata.name)}:\n`;
+            }
+
+            if (metadata.website) adderMessage += `docs: ${metadata.website.documentation}`;
+
+            if (x.nextSteps) {
+                const adderNextSteps = x.nextSteps();
+                if (adderNextSteps) adderMessage += `\n${adderNextSteps}`;
+            }
+
+            return adderMessage;
+        })
+        .join("\n\n");
+    messagePrompt("Next steps", allAddersMessage);
+}

--- a/packages/core/adder/nextSteps.ts
+++ b/packages/core/adder/nextSteps.ts
@@ -6,22 +6,18 @@ import { green } from "picocolors";
 
 export function displayNextSteps<Args extends OptionDefinition>(adderDetails: AdderDetails<Args>[], multipleAdders: boolean) {
     const allAddersMessage = adderDetails
-        .filter((x) => x.config.integrationType == "inline")
+        .filter((x) => x.config.integrationType == "inline" && x.config.nextSteps)
         .map((x) => x.config as InlineAdderConfig<Args>)
         .map((x) => {
+            // only doing this to narrow the type, `nextSteps` should already exist here
+            if (!x.nextSteps) return "";
             const metadata = x.metadata;
             let adderMessage = "";
             if (multipleAdders) {
                 adderMessage = `${green(metadata.name)}:\n`;
             }
-
-            if (metadata.website) adderMessage += `docs: ${metadata.website.documentation}`;
-
-            if (x.nextSteps) {
-                const adderNextSteps = x.nextSteps();
-                if (adderNextSteps) adderMessage += `\n${adderNextSteps}`;
-            }
-
+            const adderNextSteps = x.nextSteps();
+            adderMessage += `- ${adderNextSteps.join("\n- ")}`;
             return adderMessage;
         })
         .join("\n\n");

--- a/packages/core/adder/nextSteps.ts
+++ b/packages/core/adder/nextSteps.ts
@@ -1,7 +1,7 @@
 import { messagePrompt } from "../utils/prompts";
-import { InlineAdderConfig } from "./config";
-import { AdderDetails, AddersExecutionPlan } from "./execute";
-import { OptionDefinition, OptionValues } from "./options";
+import type { InlineAdderConfig } from "./config";
+import type { AdderDetails, AddersExecutionPlan } from "./execute";
+import type { OptionDefinition, OptionValues } from "./options";
 import pc from "picocolors";
 
 export function displayNextSteps<Args extends OptionDefinition>(

--- a/packages/core/adder/nextSteps.ts
+++ b/packages/core/adder/nextSteps.ts
@@ -1,10 +1,14 @@
 import { messagePrompt } from "../utils/prompts";
 import { InlineAdderConfig } from "./config";
-import { AdderDetails } from "./execute";
-import { OptionDefinition } from "./options";
-import { green } from "picocolors";
+import { AdderDetails, AddersExecutionPlan } from "./execute";
+import { OptionDefinition, OptionValues } from "./options";
+import pc from "picocolors";
 
-export function displayNextSteps<Args extends OptionDefinition>(adderDetails: AdderDetails<Args>[], multipleAdders: boolean) {
+export function displayNextSteps<Args extends OptionDefinition>(
+    adderDetails: AdderDetails<Args>[],
+    multipleAdders: boolean,
+    executionPlan: AddersExecutionPlan,
+) {
     const allAddersMessage = adderDetails
         .filter((x) => x.config.integrationType == "inline" && x.config.nextSteps)
         .map((x) => x.config as InlineAdderConfig<Args>)
@@ -14,9 +18,17 @@ export function displayNextSteps<Args extends OptionDefinition>(adderDetails: Ad
             const metadata = x.metadata;
             let adderMessage = "";
             if (multipleAdders) {
-                adderMessage = `${green(metadata.name)}:\n`;
+                adderMessage = `${pc.green(metadata.name)}:\n`;
             }
-            const adderNextSteps = x.nextSteps();
+
+            const options = executionPlan.cliOptionsByAdderId[x.metadata.id] as OptionValues<Args>;
+
+            const adderNextSteps = x.nextSteps({
+                options,
+                cwd: executionPlan.workingDirectory,
+                colors: pc,
+                docs: x.metadata.website?.documentation,
+            });
             adderMessage += `- ${adderNextSteps.join("\n- ")}`;
             return adderMessage;
         })


### PR DESCRIPTION
Closes #390 

Initial implementation to gather feedback.
This is basically implemented, and you can try it out with the preview release that will be published. 

If applying multiple adders (`pnpm dlx svelte-add`) it will always print the display name of the adder and the link to the documentation. If running for one adder alone (`pnpm dlx @svelte-add/bootstrap`) it will skip the name and only print the docs link. Additionally, each adder can provide its custom text that will be displayed below the docs link (currently only implemented for the bootstrap adder).

Here are a few questions for discussion:
1. Should we always print the docs link for each adder?
2. Do the adders need any context (parameters) to generate the next steps? Would the selected options and the cwd be useful?
3. Should the adders have the possibility to print colored text? If yes, should we expose `picocolors` or should it be a dependency of the adders that actually need it.
4. What would be a useful next step for lets say the tailwindcss adder?