### PR TITLE
chore: fix all type imports and exports

### DIFF
--- a/.changeset/wild-shoes-argue.md
+++ b/.changeset/wild-shoes-argue.md
@@ -1,0 +1,8 @@
+---
+"@svelte-add/ast-manipulation": patch
+"@svelte-add/testing-library": patch
+"@svelte-add/ast-tooling": patch
+"@svelte-add/core": patch
+---
+
+chore: fixed type imports and exports

--- a/packages/ast-manipulation/html/index.ts
+++ b/packages/ast-manipulation/html/index.ts
@@ -1,4 +1,4 @@
-import { HtmlChildNode, HtmlDocument, HtmlElement, HtmlElementType, parseHtml } from "@svelte-add/ast-tooling";
+import { type HtmlChildNode, HtmlDocument, HtmlElement, HtmlElementType, parseHtml } from "@svelte-add/ast-tooling";
 
 export type HtmlAstEditor = {
     ast: HtmlDocument;

--- a/packages/ast-manipulation/index.ts
+++ b/packages/ast-manipulation/index.ts
@@ -1,8 +1,8 @@
-import { getCssAstEditor, CssAstEditor } from "./css/index.js";
-import { getHtmlAstEditor, HtmlAstEditor } from "./html/index.js";
-import { getJsAstEditor, JsAstEditor } from "./js/index.js";
+import { getCssAstEditor, type CssAstEditor } from "./css/index.js";
+import { getHtmlAstEditor, type HtmlAstEditor } from "./html/index.js";
+import { getJsAstEditor, type JsAstEditor } from "./js/index.js";
 
-export { getCssAstEditor, getHtmlAstEditor, getJsAstEditor, CssAstEditor, HtmlAstEditor, JsAstEditor };
+export { getCssAstEditor, getHtmlAstEditor, getJsAstEditor, type CssAstEditor, type HtmlAstEditor, type JsAstEditor };
 
 export type SvelteAstEditor = {
     js: JsAstEditor;

--- a/packages/ast-manipulation/js/array.ts
+++ b/packages/ast-manipulation/js/array.ts
@@ -1,5 +1,5 @@
-import { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 import { areNodesEqual } from "./common";
+import type { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export function createEmpty() {
     const arrayExpression: AstTypes.ArrayExpression = {

--- a/packages/ast-manipulation/js/common.ts
+++ b/packages/ast-manipulation/js/common.ts
@@ -1,4 +1,4 @@
-import { AstKinds, AstTypes, Walker, parseScript, serializeScript } from "@svelte-add/ast-tooling";
+import { type AstKinds, type AstTypes, Walker, parseScript, serializeScript } from "@svelte-add/ast-tooling";
 
 export function addJsDocTypeComment(node: AstTypes.Node, type: string) {
     const comment: AstTypes.CommentBlock = {

--- a/packages/ast-manipulation/js/exports.ts
+++ b/packages/ast-manipulation/js/exports.ts
@@ -1,4 +1,4 @@
-import { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
+import type { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export type ExportDefaultReturn<T> = {
     astNode: AstTypes.ExportDefaultDeclaration;

--- a/packages/ast-manipulation/js/function.ts
+++ b/packages/ast-manipulation/js/function.ts
@@ -1,4 +1,4 @@
-import { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
+import type { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export function call(name: string, args: string[]) {
     const callExpression: AstTypes.CallExpression = {

--- a/packages/ast-manipulation/js/imports.ts
+++ b/packages/ast-manipulation/js/imports.ts
@@ -1,4 +1,4 @@
-import { AstTypes } from "@svelte-add/ast-tooling";
+import type { AstTypes } from "@svelte-add/ast-tooling";
 import { areNodesEqual } from "./common.js";
 
 export function addEmpty(ast: AstTypes.Program, importFrom: string) {

--- a/packages/ast-manipulation/js/index.ts
+++ b/packages/ast-manipulation/js/index.ts
@@ -5,7 +5,7 @@ import * as FunctionUtils from "./function.js";
 import * as ImportUtils from "./imports.js";
 import * as VariableUtils from "./variables.js";
 import * as ExportUtils from "./exports.js";
-import { AstTypes } from "@svelte-add/ast-tooling";
+import type { AstTypes } from "@svelte-add/ast-tooling";
 
 export type JsAstEditor = {
     ast: AstTypes.Program;

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -1,4 +1,4 @@
-import { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
+import type { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier>(
     ast: AstTypes.ObjectExpression,

--- a/packages/ast-manipulation/js/variables.ts
+++ b/packages/ast-manipulation/js/variables.ts
@@ -1,4 +1,4 @@
-import { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
+import type { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export function declaration(
     ast: AstTypes.Program | AstKinds.DeclarationKind,

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -1,15 +1,15 @@
 import { parse as tsParse } from "recast/parsers/typescript.js";
 import { parse as recastParse, print as recastPrint } from "recast";
-import { Document, Element, Text, ChildNode } from "domhandler";
+import { Document, Element, Text, type ChildNode } from "domhandler";
 import { ElementType, parseDocument } from "htmlparser2";
 import { appendChild, removeElement, textContent } from "domutils";
 import serializeDom from "dom-serializer";
 import { Root as CssAst, Declaration, Rule, AtRule, Comment } from "postcss";
 import { parse as postcssParse } from "postcss";
-import { namedTypes as AstTypes } from "ast-types";
-import * as AstKinds from "ast-types/gen/kinds";
 import * as fleece from "silver-fleece";
 import * as Walker from "zimmerframe";
+import type { namedTypes as AstTypes } from "ast-types";
+import type * as AstKinds from "ast-types/gen/kinds";
 
 /**
  * Most of the AST tooling is pretty big in bundle size and bundling takes forever.
@@ -24,7 +24,6 @@ export {
     Document as HtmlDocument,
     Element as HtmlElement,
     ElementType as HtmlElementType,
-    ChildNode as HtmlChildNode,
 
     // css
     CssAst,
@@ -33,12 +32,17 @@ export {
     AtRule,
     Comment,
 
+    // ast walker
+    Walker,
+};
+
+export type {
+    // html
+    ChildNode as HtmlChildNode,
+
     // js
     AstTypes,
     AstKinds,
-
-    // ast walker
-    Walker,
 };
 
 export function parseScript(content: string): AstTypes.Program {

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -1,13 +1,13 @@
-import { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor } from "@svelte-add/ast-manipulation";
-import { executeAdder } from "./execute.js";
 import * as remoteControl from "./remoteControl.js";
-import { CategoryInfo } from "./categories.js";
-import { OptionDefinition, OptionValues, Question } from "./options.js";
-import { FileTypes } from "../files/processors.js";
-import { Workspace } from "../utils/workspace.js";
-import { Postcondition } from "./postconditions.js";
+import { executeAdder } from "./execute.js";
+import type { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor } from "@svelte-add/ast-manipulation";
+import type { CategoryInfo } from "./categories.js";
+import type { OptionDefinition, OptionValues, Question } from "./options.js";
+import type { FileTypes } from "../files/processors.js";
+import type { Workspace } from "../utils/workspace.js";
+import type { Postcondition } from "./postconditions.js";
 
-export { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor };
+export type { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor };
 
 export type ConditionDefinition<Args extends OptionDefinition> = (Workspace: Workspace<Args>) => boolean;
 export type ConditionDefinitionWithoutExplicitArgs = ConditionDefinition<Record<string, Question>>;

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -1,8 +1,10 @@
-import path from "path";
+import path from "node:path";
+import * as pc from "picocolors";
+import { serializeJson } from "@svelte-add/ast-tooling";
 import { commonFilePaths, format, writeFile } from "../files/utils.js";
 import { type ProjectType, createProject, detectSvelteDirectory } from "../utils/create-project.js";
 import { createOrUpdateFiles } from "../files/processors.js";
-import { Package, executeCli, getPackageJson, groupBy } from "../utils/common.js";
+import { type Package, executeCli, getPackageJson, groupBy } from "../utils/common.js";
 import {
     type Workspace,
     createEmptyWorkspace,
@@ -15,18 +17,16 @@ import {
     prepareAndParseCliOptions,
     extractCommonCliOptions,
     extractAdderCliOptions,
-    AvailableCliOptionValues,
+    type AvailableCliOptionValues,
     requestMissingOptionsFromUser,
 } from "./options.js";
 import type { AdderCheckConfig, AdderConfig, ExternalAdderConfig, InlineAdderConfig } from "./config.js";
 import type { RemoteControlOptions } from "./remoteControl.js";
 import { suggestInstallingDependencies } from "../utils/dependencies.js";
-import { serializeJson } from "@svelte-add/ast-tooling";
 import { validatePreconditions } from "./preconditions.js";
-import { PromptOption, endPrompts, multiSelectPrompt, startPrompts } from "../utils/prompts.js";
-import { CategoryKeys, categories } from "./categories.js";
+import { type PromptOption, endPrompts, multiSelectPrompt, startPrompts } from "../utils/prompts.js";
+import { type CategoryKeys, categories } from "./categories.js";
 import { checkPostconditions, printUnmetPostconditions } from "./postconditions.js";
-import { gray } from "picocolors";
 
 export type AdderDetails<Args extends OptionDefinition> = {
     config: AdderConfig<Args>;
@@ -102,7 +102,7 @@ async function executePlan<Args extends OptionDefinition>(
     const isExecutingMultipleAdders = adderDetails.length > 1;
 
     if (!isTesting) {
-        console.log(gray(`${executingAdder.name} version ${executingAdder.version}\n`));
+        console.log(pc.gray(`${executingAdder.name} version ${executingAdder.version}\n`));
         startPrompts(`Welcome to Svelte Add!`);
     }
 

--- a/packages/core/adder/options.ts
+++ b/packages/core/adder/options.ts
@@ -1,6 +1,6 @@
 import { type OptionValues as CliOptionValues, program } from "commander";
-import { AdderDetails, AddersExecutionPlan } from "./execute.js";
 import { booleanPrompt, selectPrompt, textPrompt, type PromptOption } from "../utils/prompts.js";
+import type { AdderDetails, AddersExecutionPlan } from "./execute.js";
 
 export type BooleanQuestion = {
     type: "boolean";

--- a/packages/core/adder/postconditions.ts
+++ b/packages/core/adder/postconditions.ts
@@ -1,9 +1,9 @@
-import { Workspace } from "../utils/workspace";
-import { AdderCheckConfig, AdderConfig } from "./config";
-import { OptionDefinition } from "./options";
-import { fileExistsWorkspace, readFile } from "../files/utils";
-import { yellow } from "picocolors";
+import * as pc from "picocolors";
 import { messagePrompt } from "../utils/prompts";
+import { fileExistsWorkspace, readFile } from "../files/utils";
+import type { Workspace } from "../utils/workspace";
+import type { AdderCheckConfig, AdderConfig } from "./config";
+import type { OptionDefinition } from "./options";
 
 export type PreconditionParameters<Args extends OptionDefinition> = {
     workspace: Workspace<Args>;
@@ -61,7 +61,7 @@ async function fileContains<Args extends OptionDefinition>(
 }
 
 export function printUnmetPostconditions(unmetPostconditions: string[]) {
-    const postconditionList = unmetPostconditions.map((x) => yellow(`- ${x}`)).join("\n");
+    const postconditionList = unmetPostconditions.map((x) => pc.yellow(`- ${x}`)).join("\n");
     const additionalText = `Postconditions are not supposed to fail.
 Please open an issue providing the full console output:
 https://github.com/svelte-add/svelte-add/issues/new/choose`;

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -1,10 +1,10 @@
+import * as pc from "picocolors";
 import { booleanPrompt, endPrompts, messagePrompt } from "../utils/prompts.js";
-import { AdderDetails } from "./execute.js";
-import { OptionDefinition } from "./options.js";
-import { yellow } from "picocolors";
-import { Precondition } from "./config.js";
 import { executeCli } from "../utils/common.js";
-import { ProjectType } from "../utils/create-project.js";
+import type { AdderDetails } from "./execute.js";
+import type { Precondition } from "./config.js";
+import type { OptionDefinition } from "./options.js";
+import type { ProjectType } from "../utils/create-project.js";
 
 function getGlobalPreconditions<Args extends OptionDefinition>(
     executingCli: string,
@@ -116,7 +116,7 @@ export async function validatePreconditions<Args extends OptionDefinition>(
                     message = `${name}: ${message}`;
                 }
 
-                message = yellow(message);
+                message = pc.yellow(message);
                 preconditionLog.push(message);
             }
 

--- a/packages/core/files/processors.ts
+++ b/packages/core/files/processors.ts
@@ -1,8 +1,8 @@
 import {
-    CssAstEditor,
-    HtmlAstEditor,
-    JsAstEditor,
-    SvelteAstEditor,
+    type CssAstEditor,
+    type HtmlAstEditor,
+    type JsAstEditor,
+    type SvelteAstEditor,
     getCssAstEditor,
     getHtmlAstEditor,
     getJsAstEditor,
@@ -20,9 +20,9 @@ import {
     serializeSvelteFile,
 } from "@svelte-add/ast-tooling";
 import { fileExistsWorkspace, format, readFile, writeFile } from "./utils.js";
-import { ConditionDefinition } from "../adder/config.js";
-import { OptionDefinition } from "../adder/options.js";
-import { Workspace } from "../utils/workspace.js";
+import type { ConditionDefinition } from "../adder/config.js";
+import type { OptionDefinition } from "../adder/options.js";
+import type { Workspace } from "../utils/workspace.js";
 
 export type BaseFile<Args extends OptionDefinition> = {
     name: (options: Workspace<Args>) => string;

--- a/packages/core/internal.ts
+++ b/packages/core/internal.ts
@@ -2,7 +2,7 @@ import * as remoteControl from "./adder/remoteControl.js";
 import { executeAdder, executeAdders, determineWorkingDirectory } from "./adder/execute.js";
 import { createOrUpdateFiles } from "./files/processors.js";
 import { createEmptyWorkspace, populateWorkspaceDetails } from "./utils/workspace.js";
-import { PromptOption, endPrompts, multiSelectPrompt, textPrompt, startPrompts } from "./utils/prompts.js";
+import { type PromptOption, endPrompts, multiSelectPrompt, textPrompt, startPrompts } from "./utils/prompts.js";
 import { suggestInstallingDependencies } from "./utils/dependencies.js";
 import { groupBy } from "./utils/common.js";
 import { availableCliOptions, type AvailableCliOptions } from "./adder/options.js";
@@ -15,7 +15,6 @@ export {
     executeAdders,
     populateWorkspaceDetails,
     determineWorkingDirectory,
-    PromptOption,
     endPrompts,
     multiSelectPrompt,
     textPrompt,
@@ -23,5 +22,6 @@ export {
     suggestInstallingDependencies,
     groupBy,
     availableCliOptions,
-    AvailableCliOptions,
 };
+
+export type { PromptOption, AvailableCliOptions };

--- a/packages/dev-utils/utils/generate-readme.ts
+++ b/packages/dev-utils/utils/generate-readme.ts
@@ -1,8 +1,8 @@
 import { getAdderConfig, getAdderList } from "svelte-add/website";
 import { writeFile } from "fs/promises";
 import { availableCliOptions } from "@svelte-add/core/internal";
-import { AdderConfig } from "@svelte-add/core/adder/config";
-import { Question } from "@svelte-add/core/adder/options";
+import type { AdderConfig } from "@svelte-add/core/adder/config";
+import type { Question } from "@svelte-add/core/adder/options";
 
 const domain = "https://svelte-add.com";
 const codeTagStart = "```sh";

--- a/packages/dev-utils/utils/update-dependencies.ts
+++ b/packages/dev-utils/utils/update-dependencies.ts
@@ -1,10 +1,10 @@
+import { readdirSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import { run } from "npm-check-updates";
-import { readdirSync } from "fs";
-import { readFile, writeFile } from "fs/promises";
-import { AstTypes, parseScript, serializeScript } from "@svelte-add/ast-tooling";
+import { type AstTypes, parseScript, serializeScript } from "@svelte-add/ast-tooling";
 import { getJsAstEditor } from "@svelte-add/ast-manipulation";
-import { Package } from "@svelte-add/core/utils/common";
-import { spawnSync } from "child_process";
+import type { Package } from "@svelte-add/core/utils/common";
 
 export async function updateDependencies() {
     await updatePackageJson();

--- a/packages/dev-utils/utils/update-packages.ts
+++ b/packages/dev-utils/utils/update-packages.ts
@@ -1,8 +1,8 @@
 import { getAdderConfig, getAdderList } from "svelte-add/website";
 import { readFile, writeFile } from "fs/promises";
-import { Question } from "@svelte-add/core/adder/options";
-import { AdderConfig } from "@svelte-add/core/adder/config";
-import { Package } from "@svelte-add/core/utils/common";
+import type { Question } from "@svelte-add/core/adder/options";
+import type { AdderConfig } from "@svelte-add/core/adder/config";
+import type { Package } from "@svelte-add/core/utils/common";
 
 const repoUrl = "https://github.com/svelte-add/svelte-add";
 

--- a/packages/testing-library/index.ts
+++ b/packages/testing-library/index.ts
@@ -1,9 +1,9 @@
-import { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
+import { rm } from "node:fs/promises";
 import { generateTestCases, runTestCases } from "./utils/test-cases";
-import { rm } from "fs/promises";
 import { getTemplatesDirectory } from "./utils/workspace";
 import { downloadProjectTemplates } from "./utils/create-project";
 import { remoteControl } from "@svelte-add/core/internal";
+import type { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
 
 export type TestOptions = {
     headless: boolean;

--- a/packages/testing-library/utils/dev-server.ts
+++ b/packages/testing-library/utils/dev-server.ts
@@ -1,6 +1,6 @@
-import { executeCli } from "@svelte-add/core";
-import { ChildProcessWithoutNullStreams } from "child_process";
 import terminate from "terminate";
+import { executeCli } from "@svelte-add/core";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
 export async function startDevServer(
     output: string,

--- a/packages/testing-library/utils/test-cases.ts
+++ b/packages/testing-library/utils/test-cases.ts
@@ -1,17 +1,17 @@
+import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
 import { ProjectTypesList } from "./create-project";
-import { join } from "path";
 import { runTests } from "./test";
 import { uid } from "uid";
-import { mkdir } from "fs/promises";
 import { startDevServer, stopDevServer } from "./dev-server";
 import { startBrowser, stopBrowser } from "./browser-control";
 import { getTemplatesDirectory, installDependencies, prepareWorkspaceWithTemplate, saveOptionsFile } from "./workspace";
 import { runAdder } from "./adder";
 import { textPrompt } from "@svelte-add/core/internal";
 import * as Throttle from "promise-parallel-throttle";
-import { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
-import { TestOptions } from "..";
-import { OptionValues, Question } from "@svelte-add/core/adder/options";
+import type { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
+import type { TestOptions } from "..";
+import type { OptionValues, Question } from "@svelte-add/core/adder/options";
 
 export type TestCase = {
     template: string;

--- a/packages/testing-library/utils/workspace.ts
+++ b/packages/testing-library/utils/workspace.ts
@@ -1,8 +1,8 @@
-import { cp, mkdir, writeFile } from "fs/promises";
-import { join } from "path";
-import { TestOptions } from "..";
+import { join } from "node:path";
+import { cp, mkdir, writeFile } from "node:fs/promises";
 import { executeCli } from "@svelte-add/core";
-import { OptionValues, Question } from "@svelte-add/core/adder/options";
+import type { TestOptions } from "..";
+import type { OptionValues, Question } from "@svelte-add/core/adder/options";
 
 const templatesDirectory = "templates";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,11 @@
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "declaration": true,
-        "allowSyntheticDefaultImports": true,
         "sourceMap": true,
         "strict": true,
-        "outDir": "build/"
+        "outDir": "build/",
+        "esModuleInterop": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true
     }
 }


### PR DESCRIPTION
This PR enables [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) which will mainly be helpful for us in catching cases where we're not properly importing and exporting types