### PR TITLE
feat: Single screen CLI

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,8 @@ export default tseslint.config(
             "packages/website/.svelte-kit",
             "packages/website/build",
             "packages/website",
+            "packages/clack-core",
+            "packages/clack-prompts",
             "temp",
         ],
     },

--- a/packages/clack-core/CHANGELOG.md
+++ b/packages/clack-core/CHANGELOG.md
@@ -1,0 +1,199 @@
+# @clack/core
+
+## 0.4.0
+
+### Minor Changes
+
+- 127b7f0: feat: added `selectableGroups` option for inactive group headers for `GroupMultiSelectPrompt`
+
+## 0.3.4
+
+### Patch Changes
+
+- a04e418: fix(@clack/core): keyboard input not working after await in spinner
+- 4f6fcf5: feat(@clack/core): allow tab completion for placeholders
+
+## 0.3.3
+
+### Patch Changes
+
+- cd79076: fix: restore raw mode on unblock
+
+## 0.3.2
+
+### Patch Changes
+
+- c96eda5: Enable hard line-wrapping behavior for long words without spaces
+
+## 0.3.1
+
+### Patch Changes
+
+- 58a1df1: Fix line duplication bug by automatically wrapping prompts to `process.stdout.columns`
+
+## 0.3.0
+
+### Minor Changes
+
+- 8a4a12f: Add `GroupMultiSelect` prompt
+
+### Patch Changes
+
+- 8a4a12f: add `groupMultiselect` prompt
+
+## 0.2.1
+
+### Patch Changes
+
+- ec812b6: fix `readline` hang on Windows
+
+## 0.2.0
+
+### Minor Changes
+
+- d74dd05: Adds a `selectKey` prompt type
+- 54c1bc3: **Breaking Change** `multiselect` has renamed `initialValue` to `initialValues`
+
+## 0.1.9
+
+### Patch Changes
+
+- 1251132: Multiselect: return `Value[]` instead of `Option[]`.
+- 8994382: Add a password prompt to `@clack/prompts`
+
+## 0.1.8
+
+### Patch Changes
+
+- d96071c: Don't mutate `initialValue` in `multiselect`, fix parameter type for `validate()`.
+
+  Credits to @banjo for the bug report and initial PR!
+
+## 0.1.7
+
+### Patch Changes
+
+- 6d9e675: Add support for neovim cursor motion (`hjkl`)
+
+  Thanks [@esau-morais](https://github.com/esau-morais) for the assist!
+
+## 0.1.6
+
+### Patch Changes
+
+- 7fb5375: Adds a new `defaultValue` option to the text prompt, removes automatic usage of the placeholder value.
+
+## 0.1.5
+
+### Patch Changes
+
+- de1314e: Support `required` option for multi-select
+
+## 0.1.4
+
+### Patch Changes
+
+- ca77da1: Fix multiselect initial value logic
+- 8aed606: Fix `MaxListenersExceededWarning` by detaching `stdin` listeners on close
+
+## 0.1.3
+
+### Patch Changes
+
+- a99c458: Support `initialValue` option for text prompt
+
+## 0.1.2
+
+### Patch Changes
+
+- Allow isCancel to type guard any unknown value
+- 7dcad8f: Allow placeholder to be passed to TextPrompt
+- 2242f13: Fix multiselect returning undefined
+- b1341d6: Improved placeholder handling
+
+## 0.1.1
+
+### Patch Changes
+
+- 4be7dbf: Ensure raw mode is unset on submit
+- b480679: Preserve value if validation fails
+
+## 0.1.0
+
+### Minor Changes
+
+- 7015ec9: Create new prompt: multi-select
+
+## 0.0.12
+
+### Patch Changes
+
+- 9d371c3: Fix rendering bug when using y/n to confirm
+
+## 0.0.11
+
+### Patch Changes
+
+- 441d5b7: fix select return undefined
+- d20ef2a: Update keywords, URLs
+- fe13c2f: fix cursor missing after submit
+
+## 0.0.10
+
+### Patch Changes
+
+- a0cb382: Add `main` entrypoint
+
+## 0.0.9
+
+### Patch Changes
+
+- Fix node@16 issue (cannot read "createInterface" of undefined)
+
+## 0.0.8
+
+### Patch Changes
+
+- a4b5e13: Bug fixes, exposes `block` utility
+
+## 0.0.7
+
+### Patch Changes
+
+- Fix cursor bug
+
+## 0.0.6
+
+### Patch Changes
+
+- Fix error with character check
+
+## 0.0.5
+
+### Patch Changes
+
+- 491f9e0: update readme
+
+## 0.0.4
+
+### Patch Changes
+
+- 7372d5c: Fix bug with line deletion
+
+## 0.0.3
+
+### Patch Changes
+
+- 5605d28: Do not bundle dependencies (take II)
+
+## 0.0.2
+
+### Patch Changes
+
+- 2ee67cb: don't bundle deps
+
+## 0.0.1
+
+### Patch Changes
+
+- 306598e: Initial publish, still WIP

--- a/packages/clack-core/LICENSE
+++ b/packages/clack-core/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+`ansi-regex` is adapted from https://github.com/chalk/ansi-regex
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/clack-core/README.md
+++ b/packages/clack-core/README.md
@@ -1,0 +1,22 @@
+# `@clack/core`
+
+Clack contains low-level primitives for implementing your own command-line applications.
+
+Currently, `TextPrompt`, `SelectPrompt`, and `ConfirmPrompt` are exposed as well as the base `Prompt` class.
+
+Each `Prompt` accepts a `render` function.
+
+```js
+import { TextPrompt, isCancel } from "@clack/core";
+
+const p = new TextPrompt({
+    render() {
+        return `What's your name?\n${this.valueWithCursor}`;
+    },
+});
+
+const name = await p.prompt();
+if (isCancel(name)) {
+    process.exit(0);
+}
+```

--- a/packages/clack-core/index.ts
+++ b/packages/clack-core/index.ts
@@ -1,0 +1,10 @@
+export { default as ConfirmPrompt } from "./src/prompts/confirm";
+export { default as GroupMultiSelectPrompt } from "./src/prompts/group-multiselect";
+export { default as MultiSelectPrompt } from "./src/prompts/multi-select";
+export { default as PasswordPrompt } from "./src/prompts/password";
+export { default as Prompt, isCancel } from "./src/prompts/prompt";
+export type { State } from "./src/prompts/prompt";
+export { default as SelectPrompt } from "./src/prompts/select";
+export { default as SelectKeyPrompt } from "./src/prompts/select-key";
+export { default as TextPrompt } from "./src/prompts/text";
+export { block } from "./src/utils";

--- a/packages/clack-core/package.json
+++ b/packages/clack-core/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@svelte-add/clack-core",
+    "version": "0.4.0",
+    "type": "module",
+    "module": "./build/index.mjs",
+    "exports": {
+        ".": {
+            "types": "./build/index.d.ts",
+            "default": "./build/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "types": "./build/index.d.ts",
+    "bugs": "https://github.com/svelte-add/svelte-add/issues",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/svelte-add/svelte-add/tree/main/packages/clack-prompts"
+    },
+    "files": [
+        "build"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "sisteransi": "^1.0.5"
+    },
+    "devDependencies": {
+        "picocolors": "^1.0.0",
+        "wrap-ansi": "^8.1.0"
+    }
+}

--- a/packages/clack-core/src/prompts/confirm.ts
+++ b/packages/clack-core/src/prompts/confirm.ts
@@ -1,0 +1,37 @@
+import { cursor } from "sisteransi";
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+interface ConfirmOptions extends PromptOptions<ConfirmPrompt> {
+    active: string;
+    inactive: string;
+    initialValue?: boolean;
+}
+export default class ConfirmPrompt extends Prompt {
+    get cursor() {
+        return this.value ? 0 : 1;
+    }
+
+    private get _value() {
+        return this.cursor === 0;
+    }
+
+    constructor(opts: ConfirmOptions) {
+        super(opts, false);
+        this.value = opts.initialValue ? true : false;
+
+        this.on("value", () => {
+            this.value = this._value;
+        });
+
+        this.on("confirm", (confirm) => {
+            this.output.write(cursor.move(0, -1));
+            this.value = confirm;
+            this.state = "submit";
+            this.close();
+        });
+
+        this.on("cursor", () => {
+            this.value = !this.value;
+        });
+    }
+}

--- a/packages/clack-core/src/prompts/group-multiselect.ts
+++ b/packages/clack-core/src/prompts/group-multiselect.ts
@@ -1,0 +1,77 @@
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+interface GroupMultiSelectOptions<T extends { value: any }> extends PromptOptions<GroupMultiSelectPrompt<T>> {
+    options: Record<string, T[]>;
+    initialValues?: T["value"][];
+    required?: boolean;
+    cursorAt?: T["value"];
+    selectableGroups?: boolean;
+}
+export default class GroupMultiSelectPrompt<T extends { value: any }> extends Prompt {
+    options: (T & { group: string | boolean })[];
+    cursor: number = 0;
+    #selectableGroups: boolean;
+
+    getGroupItems(group: string): T[] {
+        return this.options.filter((o) => o.group === group);
+    }
+
+    isGroupSelected(group: string) {
+        const items = this.getGroupItems(group);
+        return this.#selectableGroups && items.every((i) => this.value.includes(i.value));
+    }
+
+    private toggleValue() {
+        const item = this.options[this.cursor];
+        if (item.group === true) {
+            const group = item.value;
+            const groupedItems = this.getGroupItems(group);
+            if (this.isGroupSelected(group)) {
+                this.value = this.value.filter((v: string) => groupedItems.findIndex((i) => i.value === v) === -1);
+            } else {
+                this.value = [...this.value, ...groupedItems.map((i) => i.value)];
+            }
+            this.value = Array.from(new Set(this.value));
+        } else {
+            const selected = this.value.includes(item.value);
+            this.value = selected ? this.value.filter((v: T["value"]) => v !== item.value) : [...this.value, item.value];
+        }
+    }
+
+    constructor(opts: GroupMultiSelectOptions<T>) {
+        super(opts, false);
+        const { options } = opts;
+        this.#selectableGroups = opts.selectableGroups ?? true;
+        this.options = Object.entries(options).flatMap(([key, option]) => [
+            { value: key, group: true, label: key },
+            ...option.map((opt) => ({ ...opt, group: key })),
+        ]) as any;
+        this.value = [...(opts.initialValues ?? [])];
+        this.cursor = Math.max(
+            this.options.findIndex(({ value }) => value === opts.cursorAt),
+            this.#selectableGroups ? 0 : 1,
+        );
+
+        this.on("cursor", (key) => {
+            switch (key) {
+                case "left":
+                case "up":
+                    this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+                    if (!this.#selectableGroups && this.options[this.cursor].group === true) {
+                        this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+                    }
+                    break;
+                case "down":
+                case "right":
+                    this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
+                    if (!this.#selectableGroups && this.options[this.cursor].group === true) {
+                        this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
+                    }
+                    break;
+                case "space":
+                    this.toggleValue();
+                    break;
+            }
+        });
+    }
+}

--- a/packages/clack-core/src/prompts/multi-select.ts
+++ b/packages/clack-core/src/prompts/multi-select.ts
@@ -1,0 +1,58 @@
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
+    options: T[];
+    initialValues?: T["value"][];
+    required?: boolean;
+    cursorAt?: T["value"];
+}
+export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
+    options: T[];
+    cursor: number = 0;
+
+    private get _value() {
+        return this.options[this.cursor].value;
+    }
+
+    private toggleAll() {
+        const allSelected = this.value.length === this.options.length;
+        this.value = allSelected ? [] : this.options.map((v) => v.value);
+    }
+
+    private toggleValue() {
+        const selected = this.value.includes(this._value);
+        this.value = selected ? this.value.filter((value: T["value"]) => value !== this._value) : [...this.value, this._value];
+    }
+
+    constructor(opts: MultiSelectOptions<T>) {
+        super(opts, false);
+
+        this.options = opts.options;
+        this.value = [...(opts.initialValues ?? [])];
+        this.cursor = Math.max(
+            this.options.findIndex(({ value }) => value === opts.cursorAt),
+            0,
+        );
+        this.on("key", (char) => {
+            if (char === "a") {
+                this.toggleAll();
+            }
+        });
+
+        this.on("cursor", (key) => {
+            switch (key) {
+                case "left":
+                case "up":
+                    this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+                    break;
+                case "down":
+                case "right":
+                    this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
+                    break;
+                case "space":
+                    this.toggleValue();
+                    break;
+            }
+        });
+    }
+}

--- a/packages/clack-core/src/prompts/password.ts
+++ b/packages/clack-core/src/prompts/password.ts
@@ -1,0 +1,33 @@
+import color from "picocolors";
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+interface PasswordOptions extends PromptOptions<PasswordPrompt> {
+    mask?: string;
+}
+export default class PasswordPrompt extends Prompt {
+    valueWithCursor = "";
+    private _mask = "•";
+    get cursor() {
+        return this._cursor;
+    }
+    get masked() {
+        return this.value.replaceAll(/./g, this._mask);
+    }
+    constructor({ mask, ...opts }: PasswordOptions) {
+        super(opts);
+        this._mask = mask ?? "•";
+
+        this.on("finalize", () => {
+            this.valueWithCursor = this.masked;
+        });
+        this.on("value", () => {
+            if (this.cursor >= this.value.length) {
+                this.valueWithCursor = `${this.masked}${color.inverse(color.hidden("_"))}`;
+            } else {
+                const s1 = this.masked.slice(0, this.cursor);
+                const s2 = this.masked.slice(this.cursor);
+                this.valueWithCursor = `${s1}${color.inverse(s2[0])}${s2.slice(1)}`;
+            }
+        });
+    }
+}

--- a/packages/clack-core/src/prompts/prompt.ts
+++ b/packages/clack-core/src/prompts/prompt.ts
@@ -1,0 +1,257 @@
+import type { Key, ReadLine } from "node:readline";
+
+import { stdin, stdout } from "node:process";
+import readline from "node:readline";
+import { Readable, Writable } from "node:stream";
+import { WriteStream } from "node:tty";
+import { cursor, erase } from "sisteransi";
+import wrap from "wrap-ansi";
+
+function diffLines(a: string, b: string) {
+    if (a === b) return;
+
+    const aLines = a.split("\n");
+    const bLines = b.split("\n");
+    const diff: number[] = [];
+
+    for (let i = 0; i < Math.max(aLines.length, bLines.length); i++) {
+        if (aLines[i] !== bLines[i]) diff.push(i);
+    }
+
+    return diff;
+}
+
+const cancel = Symbol("clack:cancel");
+export function isCancel(value: unknown): value is symbol {
+    return value === cancel;
+}
+
+function setRawMode(input: Readable, value: boolean) {
+    if ((input as typeof stdin).isTTY) (input as typeof stdin).setRawMode(value);
+}
+
+const aliases = new Map([
+    ["k", "up"],
+    ["j", "down"],
+    ["h", "left"],
+    ["l", "right"],
+]);
+const keys = new Set(["up", "down", "left", "right", "space", "enter"]);
+
+export interface PromptOptions<Self extends Prompt> {
+    render(this: Omit<Self, "prompt">): string | void;
+    placeholder?: string;
+    initialValue?: any;
+    validate?: ((value: any) => string | void) | undefined;
+    input?: Readable;
+    output?: Writable;
+    debug?: boolean;
+}
+
+export type State = "initial" | "active" | "cancel" | "submit" | "error";
+
+export default class Prompt {
+    protected input: Readable;
+    protected output: Writable;
+    private rl!: ReadLine;
+    private opts: Omit<PromptOptions<Prompt>, "render" | "input" | "output">;
+    private _track: boolean = false;
+    private _render: (context: Omit<Prompt, "prompt">) => string | void;
+    protected _cursor: number = 0;
+
+    public state: State = "initial";
+    public value: any;
+    public error: string = "";
+
+    constructor({ render, input = stdin, output = stdout, ...opts }: PromptOptions<Prompt>, trackValue: boolean = true) {
+        this.opts = opts;
+        this.onKeypress = this.onKeypress.bind(this);
+        this.close = this.close.bind(this);
+        this.render = this.render.bind(this);
+        this._render = render.bind(this);
+        this._track = trackValue;
+
+        this.input = input;
+        this.output = output;
+    }
+
+    public prompt() {
+        const sink = new WriteStream(0);
+        sink._write = (chunk, encoding, done) => {
+            if (this._track) {
+                this.value = this.rl.line.replace(/\t/g, "");
+                this._cursor = this.rl.cursor;
+                this.emit("value", this.value);
+            }
+            done();
+        };
+        this.input.pipe(sink);
+
+        this.rl = readline.createInterface({
+            input: this.input,
+            output: sink,
+            tabSize: 2,
+            prompt: "",
+            escapeCodeTimeout: 50,
+        });
+        readline.emitKeypressEvents(this.input, this.rl);
+        this.rl.prompt();
+        if (this.opts.initialValue !== undefined && this._track) {
+            this.rl.write(this.opts.initialValue);
+        }
+
+        this.input.on("keypress", this.onKeypress);
+        setRawMode(this.input, true);
+        this.output.on("resize", this.render);
+
+        this.render();
+
+        return new Promise<string | symbol>((resolve, reject) => {
+            this.once("submit", () => {
+                this.output.write(cursor.show);
+                this.output.off("resize", this.render);
+                setRawMode(this.input, false);
+                resolve(this.value);
+            });
+            this.once("cancel", () => {
+                this.output.write(cursor.show);
+                this.output.off("resize", this.render);
+                setRawMode(this.input, false);
+                resolve(cancel);
+            });
+        });
+    }
+
+    private subscribers = new Map<string, { cb: (...args: any) => any; once?: boolean }[]>();
+    public on(event: string, cb: (...args: any) => any) {
+        const arr = this.subscribers.get(event) ?? [];
+        arr.push({ cb });
+        this.subscribers.set(event, arr);
+    }
+    public once(event: string, cb: (...args: any) => any) {
+        const arr = this.subscribers.get(event) ?? [];
+        arr.push({ cb, once: true });
+        this.subscribers.set(event, arr);
+    }
+    public emit(event: string, ...data: any[]) {
+        const cbs = this.subscribers.get(event) ?? [];
+        const cleanup: (() => void)[] = [];
+        for (const subscriber of cbs) {
+            subscriber.cb(...data);
+            if (subscriber.once) {
+                cleanup.push(() => cbs.splice(cbs.indexOf(subscriber), 1));
+            }
+        }
+        for (const cb of cleanup) {
+            cb();
+        }
+    }
+    private unsubscribe() {
+        this.subscribers.clear();
+    }
+
+    private onKeypress(char: string, key?: Key) {
+        if (this.state === "error") {
+            this.state = "active";
+        }
+        if (key?.name && !this._track && aliases.has(key.name)) {
+            this.emit("cursor", aliases.get(key.name));
+        }
+        if (key?.name && keys.has(key.name)) {
+            this.emit("cursor", key.name);
+        }
+        if (char && (char.toLowerCase() === "y" || char.toLowerCase() === "n")) {
+            this.emit("confirm", char.toLowerCase() === "y");
+        }
+        if (char === "\t" && this.opts.placeholder) {
+            if (!this.value) {
+                this.rl.write(this.opts.placeholder);
+                this.emit("value", this.opts.placeholder);
+            }
+        }
+        if (char) {
+            this.emit("key", char.toLowerCase());
+        }
+
+        if (key?.name === "return") {
+            if (this.opts.validate) {
+                const problem = this.opts.validate(this.value);
+                if (problem) {
+                    this.error = problem;
+                    this.state = "error";
+                    this.rl.write(this.value);
+                }
+            }
+            if (this.state !== "error") {
+                this.state = "submit";
+            }
+        }
+        if (char === "\x03") {
+            this.state = "cancel";
+        }
+        if (this.state === "submit" || this.state === "cancel") {
+            this.emit("finalize");
+        }
+        this.render();
+        if (this.state === "submit" || this.state === "cancel") {
+            this.close();
+        }
+    }
+
+    protected close() {
+        this.input.unpipe();
+        this.input.removeListener("keypress", this.onKeypress);
+        this.output.write("\n");
+        setRawMode(this.input, false);
+        this.rl.close();
+        this.emit(this.state, this.value);
+        this.unsubscribe();
+    }
+
+    private restoreCursor() {
+        const lines = wrap(this._prevFrame, process.stdout.columns, { hard: true }).split("\n").length - 1;
+        this.output.write(cursor.move(-999, lines * -1));
+    }
+
+    private _prevFrame = "";
+    private render() {
+        const frame = wrap(this._render(this) ?? "", process.stdout.columns, { hard: true });
+        if (frame === this._prevFrame) return;
+
+        if (this.state === "initial") {
+            this.output.write(cursor.hide);
+        } else {
+            const diff = diffLines(this._prevFrame, frame);
+            this.restoreCursor();
+            // If a single line has changed, only update that line
+            if (diff && diff?.length === 1) {
+                const diffLine = diff[0];
+                this.output.write(cursor.move(0, diffLine));
+                this.output.write(erase.lines(1));
+                const lines = frame.split("\n");
+                this.output.write(lines[diffLine]);
+                this._prevFrame = frame;
+                this.output.write(cursor.move(0, lines.length - diffLine - 1));
+                return;
+                // If many lines have changed, rerender everything past the first line
+            } else if (diff && diff?.length > 1) {
+                const diffLine = diff[0];
+                this.output.write(cursor.move(0, diffLine));
+                this.output.write(erase.down());
+                const lines = frame.split("\n");
+                const newLines = lines.slice(diffLine);
+                this.output.write(newLines.join("\n"));
+                this._prevFrame = frame;
+                return;
+            }
+
+            this.output.write(erase.down());
+        }
+
+        this.output.write(frame);
+        if (this.state === "initial") {
+            this.state = "active";
+        }
+        this._prevFrame = frame;
+    }
+}

--- a/packages/clack-core/src/prompts/select-key.ts
+++ b/packages/clack-core/src/prompts/select-key.ts
@@ -1,0 +1,27 @@
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+interface SelectKeyOptions<T extends { value: any }> extends PromptOptions<SelectKeyPrompt<T>> {
+    options: T[];
+}
+export default class SelectKeyPrompt<T extends { value: any }> extends Prompt {
+    options: T[];
+    cursor: number = 0;
+
+    constructor(opts: SelectKeyOptions<T>) {
+        super(opts, false);
+
+        this.options = opts.options;
+        const keys = this.options.map(({ value: [initial] }) => initial?.toLowerCase());
+        this.cursor = Math.max(keys.indexOf(opts.initialValue), 0);
+
+        this.on("key", (key) => {
+            if (!keys.includes(key)) return;
+            const value = this.options.find(({ value: [initial] }) => initial?.toLowerCase() === key);
+            if (value) {
+                this.value = value.value;
+                this.state = "submit";
+                this.emit("submit");
+            }
+        });
+    }
+}

--- a/packages/clack-core/src/prompts/select.ts
+++ b/packages/clack-core/src/prompts/select.ts
@@ -1,0 +1,41 @@
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
+    options: T[];
+    initialValue?: T["value"];
+}
+export default class SelectPrompt<T extends { value: any }> extends Prompt {
+    options: T[];
+    cursor: number = 0;
+
+    private get _value() {
+        return this.options[this.cursor];
+    }
+
+    private changeValue() {
+        this.value = this._value.value;
+    }
+
+    constructor(opts: SelectOptions<T>) {
+        super(opts, false);
+
+        this.options = opts.options;
+        this.cursor = this.options.findIndex(({ value }) => value === opts.initialValue);
+        if (this.cursor === -1) this.cursor = 0;
+        this.changeValue();
+
+        this.on("cursor", (key) => {
+            switch (key) {
+                case "left":
+                case "up":
+                    this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+                    break;
+                case "down":
+                case "right":
+                    this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
+                    break;
+            }
+            this.changeValue();
+        });
+    }
+}

--- a/packages/clack-core/src/prompts/text.ts
+++ b/packages/clack-core/src/prompts/text.ts
@@ -1,0 +1,33 @@
+import color from "picocolors";
+import Prompt, { type PromptOptions } from "./prompt.js";
+
+export interface TextOptions extends PromptOptions<TextPrompt> {
+    placeholder?: string;
+    defaultValue?: string;
+}
+
+export default class TextPrompt extends Prompt {
+    valueWithCursor = "";
+    get cursor() {
+        return this._cursor;
+    }
+    constructor(opts: TextOptions) {
+        super(opts);
+
+        this.on("finalize", () => {
+            if (!this.value) {
+                this.value = opts.defaultValue;
+            }
+            this.valueWithCursor = this.value;
+        });
+        this.on("value", () => {
+            if (this.cursor >= this.value.length) {
+                this.valueWithCursor = `${this.value}${color.inverse(color.hidden("_"))}`;
+            } else {
+                const s1 = this.value.slice(0, this.cursor);
+                const s2 = this.value.slice(this.cursor);
+                this.valueWithCursor = `${s1}${color.inverse(s2[0])}${s2.slice(1)}`;
+            }
+        });
+    }
+}

--- a/packages/clack-core/src/utils.ts
+++ b/packages/clack-core/src/utils.ts
@@ -1,0 +1,48 @@
+import type { Key } from "node:readline";
+
+import { stdin, stdout } from "node:process";
+import * as readline from "node:readline";
+import { cursor } from "sisteransi";
+
+const isWindows = globalThis.process.platform.startsWith("win");
+
+export function block({ input = stdin, output = stdout, overwrite = true, hideCursor = true } = {}) {
+    const rl = readline.createInterface({
+        input,
+        output,
+        prompt: "",
+        tabSize: 1,
+    });
+    readline.emitKeypressEvents(input, rl);
+    if (input.isTTY) input.setRawMode(true);
+
+    const clear = (data: Buffer, { name }: Key) => {
+        const str = String(data);
+        if (str === "\x03") {
+            process.exit(0);
+        }
+        if (!overwrite) return;
+        const dx = name === "return" ? 0 : -1;
+        const dy = name === "return" ? -1 : 0;
+
+        readline.moveCursor(output, dx, dy, () => {
+            readline.clearLine(output, 1, () => {
+                input.once("keypress", clear);
+            });
+        });
+    };
+    if (hideCursor) process.stdout.write(cursor.hide);
+    input.once("keypress", clear);
+
+    return () => {
+        input.off("keypress", clear);
+        if (hideCursor) process.stdout.write(cursor.show);
+
+        // Prevent Windows specific issues: https://github.com/natemoo-re/clack/issues/176
+        if (input.isTTY && !isWindows) input.setRawMode(false);
+
+        // @ts-expect-error fix for https://github.com/nodejs/node/issues/31762#issuecomment-1441223907
+        rl.terminal = false;
+        rl.close();
+    };
+}

--- a/packages/clack-prompts/CHANGELOG.md
+++ b/packages/clack-prompts/CHANGELOG.md
@@ -1,0 +1,282 @@
+# @clack/prompts
+
+## 0.9.0
+
+### Minor Changes
+
+- 127b7f0: feat: added `selectableGroups` option for inactive group headers for `GroupMultiSelectPrompt`
+
+### Patch Changes
+
+- 360afeb: feat: adaptative max items
+- Updated dependencies [127b7f0]
+  - @clack/core@0.4.0
+
+## 0.8.0
+
+### Minor Changes
+
+- 9acccde: Add tasks function for executing tasks in spinners
+
+### Patch Changes
+
+- b5c6b9b: Feat multiselect maxItems option
+- 50ed94a: fix: clear `spinner` hooks on `spinner.stop`
+- Updated dependencies [a04e418]
+- Updated dependencies [4f6fcf5]
+  - @clack/core@0.3.4
+
+## 0.7.0
+
+### Minor Changes
+
+- b27a701: add maxItems option to select prompt
+- 89371be: added a new method called `spinner.message(msg: string)`
+
+### Patch Changes
+
+- 52183c4: Fix `spinner` conflict with terminal on error between `spinner.start()` and `spinner.stop()`
+- ab51d29: Fixes cases where the note title length was miscalculated due to ansi characters
+- Updated dependencies [cd79076]
+  - @clack/core@0.3.3
+
+## 0.6.3
+
+### Patch Changes
+
+- c96eda5: Enable hard line-wrapping behavior for long words without spaces
+- Updated dependencies [c96eda5]
+  - @clack/core@0.3.2
+
+## 0.6.2
+
+### Patch Changes
+
+- 58a1df1: Fix line duplication bug by automatically wrapping prompts to `process.stdout.columns`
+- Updated dependencies [58a1df1]
+  - @clack/core@0.3.1
+
+## 0.6.1
+
+### Patch Changes
+
+- ca08fb6: Support complex value types for `select`, `multiselect` and `groupMultiselect`.
+
+## 0.6.0
+
+### Minor Changes
+
+- 8a4a12f: add `groupMultiselect` prompt
+- 165a1b3: Add `log` APIs. Supports `log.info`, `log.success`, `log.warn`, and `log.error`. For low-level control, `log.message` is also exposed.
+
+### Patch Changes
+
+- Updated dependencies [8a4a12f]
+- Updated dependencies [8a4a12f]
+  - @clack/core@0.3.0
+
+## 0.5.1
+
+### Patch Changes
+
+- cc11917: Update default `password` mask
+- Updated dependencies [ec812b6]
+  - @clack/core@0.2.1
+
+## 0.5.0
+
+### Minor Changes
+
+- d74dd05: Adds a `selectKey` prompt type
+- 54c1bc3: **Breaking Change** `multiselect` has renamed `initialValue` to `initialValues`
+
+### Patch Changes
+
+- Updated dependencies [d74dd05]
+- Updated dependencies [54c1bc3]
+  - @clack/core@0.2.0
+
+## 0.4.5
+
+### Patch Changes
+
+- 1251132: Multiselect: return `Value[]` instead of `Option[]`.
+- 8994382: Add a password prompt to `@clack/prompts`
+- Updated dependencies [1251132]
+- Updated dependencies [8994382]
+  - @clack/core@0.1.9
+
+## 0.4.4
+
+### Patch Changes
+
+- d96071c: Don't mutate `initialValue` in `multiselect`, fix parameter type for `validate()`.
+
+  Credits to @banjo for the bug report and initial PR!
+
+- Updated dependencies [d96071c]
+  - @clack/core@0.1.8
+
+## 0.4.3
+
+### Patch Changes
+
+- 83d890e: Fix text cancel display bug
+
+## 0.4.2
+
+### Patch Changes
+
+- Update README
+
+## 0.4.1
+
+### Patch Changes
+
+- 7fb5375: Adds a new `defaultValue` option to the text prompt, removes automatic usage of the placeholder value.
+- Updated dependencies [7fb5375]
+  - @clack/core@0.1.6
+
+## 0.4.0
+
+### Minor Changes
+
+- 61b88b6: Add `group` construct to group many prompts together
+
+### Patch Changes
+
+- de1314e: Support `required` option for multi-select
+- Updated dependencies [de1314e]
+  - @clack/core@0.1.5
+
+## 0.3.0
+
+### Minor Changes
+
+- 493c592: Improve types for select/multiselect prompts. Numbers and booleans are now supported as the `value` option.
+- 15558e3: Improved Windows/non-unicode support
+
+### Patch Changes
+
+- ca77da1: Fix multiselect initial value logic
+- Updated dependencies [ca77da1]
+- Updated dependencies [8aed606]
+  - @clack/core@0.1.4
+
+## 0.2.2
+
+### Patch Changes
+
+- 94b24d9: Fix CJS `ansi-regex` interop
+
+## 0.2.1
+
+### Patch Changes
+
+- a99c458: Support `initialValue` option for text prompt
+- Updated dependencies [a99c458]
+  - @clack/core@0.1.3
+
+## 0.2.0
+
+### Minor Changes
+
+- Improved type safety
+- b1341d6: Updated styles, new note component
+
+### Patch Changes
+
+- Updated dependencies [7dcad8f]
+- Updated dependencies [2242f13]
+- Updated dependencies [b1341d6]
+  - @clack/core@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- fa09bf5: Use circle for radio, square for checkbox
+- Updated dependencies [4be7dbf]
+- Updated dependencies [b480679]
+  - @clack/core@0.1.1
+
+## 0.1.0
+
+### Minor Changes
+
+- 7015ec9: Create new prompt: multi-select
+
+### Patch Changes
+
+- Updated dependencies [7015ec9]
+  - @clack/core@0.1.0
+
+## 0.0.10
+
+### Patch Changes
+
+- e0b49e5: Update spinner so it actually spins
+
+## 0.0.9
+
+### Patch Changes
+
+- Update README
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [9d371c3]
+  - @clack/core@0.0.12
+
+## 0.0.7
+
+### Patch Changes
+
+- Update README
+
+## 0.0.6
+
+### Patch Changes
+
+- d20ef2a: Update keywords, URLs
+- Updated dependencies [441d5b7]
+- Updated dependencies [d20ef2a]
+- Updated dependencies [fe13c2f]
+  - @clack/core@0.0.11
+
+## 0.0.5
+
+### Patch Changes
+
+- Update README
+
+## 0.0.4
+
+### Patch Changes
+
+- 80404ab: Update README
+
+## 0.0.3
+
+### Patch Changes
+
+- a0cb382: Add `main` entrypoint
+- Updated dependencies [a0cb382]
+  - @clack/core@0.0.10
+
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @clack/core@0.0.9
+
+## 0.0.1
+
+### Patch Changes
+
+- a4b5e13: Initial release
+- Updated dependencies [a4b5e13]
+  - @clack/core@0.0.8

--- a/packages/clack-prompts/LICENSE
+++ b/packages/clack-prompts/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+`ansi-regex` is adapted from https://github.com/chalk/ansi-regex
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/clack-prompts/README.md
+++ b/packages/clack-prompts/README.md
@@ -1,0 +1,174 @@
+# `@clack/prompts`
+
+Effortlessly build beautiful command-line apps 🪄 [Try the demo](https://stackblitz.com/edit/clack-prompts?file=index.js)
+
+![clack-prompt](https://github.com/natemoo-re/clack/blob/main/.github/assets/clack-demo.gif)
+
+---
+
+`@clack/prompts` is an opinionated, pre-styled wrapper around [`@clack/core`](https://www.npmjs.com/package/@clack/core).
+
+-   🤏 80% smaller than other options
+-   💎 Beautiful, minimal UI
+-   ✅ Simple API
+-   🧱 Comes with `text`, `confirm`, `select`, `multiselect`, and `spinner` components
+
+## Basics
+
+### Setup
+
+The `intro` and `outro` functions will print a message to begin or end a prompt session, respectively.
+
+```js
+import { intro, outro } from "@clack/prompts";
+
+intro(`create-my-app`);
+// Do stuff
+outro(`You're all set!`);
+```
+
+### Cancellation
+
+The `isCancel` function is a guard that detects when a user cancels a question with `CTRL + C`. You should handle this situation for each prompt, optionally providing a nice cancellation message with the `cancel` utility.
+
+```js
+import { isCancel, cancel, text } from "@clack/prompts";
+
+const value = await text(/* TODO */);
+
+if (isCancel(value)) {
+    cancel("Operation cancelled.");
+    process.exit(0);
+}
+```
+
+## Components
+
+### Text
+
+The text component accepts a single line of text.
+
+```js
+import { text } from "@clack/prompts";
+
+const meaning = await text({
+    message: "What is the meaning of life?",
+    placeholder: "Not sure",
+    initialValue: "42",
+    validate(value) {
+        if (value.length === 0) return `Value is required!`;
+    },
+});
+```
+
+### Confirm
+
+The confirm component accepts a yes or no answer. The result is a boolean value of `true` or `false`.
+
+```js
+import { confirm } from "@clack/prompts";
+
+const shouldContinue = await confirm({
+    message: "Do you want to continue?",
+});
+```
+
+### Select
+
+The select component allows a user to choose one value from a list of options. The result is the `value` prop of a given option.
+
+```js
+import { select } from "@clack/prompts";
+
+const projectType = await select({
+    message: "Pick a project type.",
+    options: [
+        { value: "ts", label: "TypeScript" },
+        { value: "js", label: "JavaScript" },
+        { value: "coffee", label: "CoffeeScript", hint: "oh no" },
+    ],
+});
+```
+
+### Multi-Select
+
+The `multiselect` component allows a user to choose many values from a list of options. The result is an array with all selected `value` props.
+
+```js
+import { multiselect } from "@clack/prompts";
+
+const additionalTools = await multiselect({
+    message: "Select additional tools.",
+    options: [
+        { value: "eslint", label: "ESLint", hint: "recommended" },
+        { value: "prettier", label: "Prettier" },
+        { value: "gh-action", label: "GitHub Action" },
+    ],
+    required: false,
+});
+```
+
+### Spinner
+
+The spinner component surfaces a pending action, such as a long-running download or dependency installation.
+
+```js
+import { spinner } from "@clack/prompts";
+
+const s = spinner();
+s.start("Installing via npm");
+// Do installation here
+s.stop("Installed via npm");
+```
+
+## Utilities
+
+### Grouping
+
+Grouping prompts together is a great way to keep your code organized. This accepts a JSON object with a name that can be used to reference the group later. The second argument is an optional but has a `onCancel` callback that will be called if the user cancels one of the prompts in the group.
+
+```js
+import * as p from "@clack/prompts";
+
+const group = await p.group(
+    {
+        name: () => p.text({ message: "What is your name?" }),
+        age: () => p.text({ message: "What is your age?" }),
+        color: ({ results }) =>
+            p.multiselect({
+                message: `What is your favorite color ${results.name}?`,
+                options: [
+                    { value: "red", label: "Red" },
+                    { value: "green", label: "Green" },
+                    { value: "blue", label: "Blue" },
+                ],
+            }),
+    },
+    {
+        // On Cancel callback that wraps the group
+        // So if the user cancels one of the prompts in the group this function will be called
+        onCancel: ({ results }) => {
+            p.cancel("Operation cancelled.");
+            process.exit(0);
+        },
+    },
+);
+
+console.log(group.name, group.age, group.color);
+```
+
+### Tasks
+
+Execute multiple tasks in spinners.
+
+```js
+await p.tasks([
+    {
+        title: "Installing via npm",
+        task: async (message) => {
+            // Do installation here
+            return "Installed via npm";
+        },
+    },
+]);
+```

--- a/packages/clack-prompts/index.ts
+++ b/packages/clack-prompts/index.ts
@@ -1,0 +1,778 @@
+import {
+    block,
+    ConfirmPrompt,
+    GroupMultiSelectPrompt,
+    isCancel,
+    MultiSelectPrompt,
+    PasswordPrompt,
+    SelectKeyPrompt,
+    SelectPrompt,
+    type State,
+    TextPrompt,
+} from "@svelte-add/clack-core";
+import isUnicodeSupported from "is-unicode-supported";
+import * as color from "picocolors";
+import { cursor, erase } from "sisteransi";
+
+export { isCancel } from "@svelte-add/clack-core";
+
+const unicode = isUnicodeSupported();
+const s = (c: string, fallback: string) => (unicode ? c : fallback);
+const S_STEP_ACTIVE = s("◆", "*");
+const S_STEP_CANCEL = s("■", "x");
+const S_STEP_ERROR = s("▲", "x");
+const S_STEP_SUBMIT = s("◇", "o");
+
+const S_BAR_START = s("┌", "T");
+const S_BAR = s("│", "|");
+const S_BAR_END = s("└", "—");
+
+const S_RADIO_ACTIVE = s("●", ">");
+const S_RADIO_INACTIVE = s("○", " ");
+const S_CHECKBOX_ACTIVE = s("◻", "[•]");
+const S_CHECKBOX_SELECTED = s("◼", "[+]");
+const S_CHECKBOX_INACTIVE = s("◻", "[ ]");
+const S_PASSWORD_MASK = s("▪", "•");
+
+const S_BAR_H = s("─", "-");
+const S_CORNER_TOP_RIGHT = s("╮", "+");
+const S_CONNECT_LEFT = s("├", "+");
+const S_CORNER_BOTTOM_RIGHT = s("╯", "+");
+
+const S_INFO = s("●", "•");
+const S_SUCCESS = s("◆", "*");
+const S_WARN = s("▲", "!");
+const S_ERROR = s("■", "x");
+
+const symbol = (state: State) => {
+    switch (state) {
+        case "initial":
+        case "active":
+            return color.cyan(S_STEP_ACTIVE);
+        case "cancel":
+            return color.red(S_STEP_CANCEL);
+        case "error":
+            return color.yellow(S_STEP_ERROR);
+        case "submit":
+            return color.green(S_STEP_SUBMIT);
+    }
+};
+
+interface LimitOptionsParams<TOption> {
+    options: TOption[];
+    maxItems: number | undefined;
+    cursor: number;
+    style: (option: TOption, active: boolean) => string;
+}
+
+const limitOptions = <TOption>(params: LimitOptionsParams<TOption>): string[] => {
+    const { cursor, options, style } = params;
+
+    const paramMaxItems = params.maxItems ?? Infinity;
+    const outputMaxItems = Math.max(process.stdout.rows - 4, 0);
+    // We clamp to minimum 5 because anything less doesn't make sense UX wise
+    const maxItems = Math.min(outputMaxItems, Math.max(paramMaxItems, 5));
+    let slidingWindowLocation = 0;
+
+    if (cursor >= slidingWindowLocation + maxItems - 3) {
+        slidingWindowLocation = Math.max(Math.min(cursor - maxItems + 3, options.length - maxItems), 0);
+    } else if (cursor < slidingWindowLocation + 2) {
+        slidingWindowLocation = Math.max(cursor - 2, 0);
+    }
+
+    const shouldRenderTopEllipsis = maxItems < options.length && slidingWindowLocation > 0;
+    const shouldRenderBottomEllipsis = maxItems < options.length && slidingWindowLocation + maxItems < options.length;
+
+    return options.slice(slidingWindowLocation, slidingWindowLocation + maxItems).map((option, i, arr) => {
+        const isTopLimit = i === 0 && shouldRenderTopEllipsis;
+        const isBottomLimit = i === arr.length - 1 && shouldRenderBottomEllipsis;
+        return isTopLimit || isBottomLimit ? color.dim("...") : style(option, i + slidingWindowLocation === cursor);
+    });
+};
+
+export interface TextOptions {
+    message: string;
+    placeholder?: string;
+    defaultValue?: string;
+    initialValue?: string;
+    validate?: (value: string) => string | void;
+}
+export const text = (opts: TextOptions) => {
+    return new TextPrompt({
+        validate: opts.validate,
+        placeholder: opts.placeholder,
+        defaultValue: opts.defaultValue,
+        initialValue: opts.initialValue,
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+            const placeholder = opts.placeholder
+                ? color.inverse(opts.placeholder[0]) + color.dim(opts.placeholder.slice(1))
+                : color.inverse(color.hidden("_"));
+            const value = !this.value ? placeholder : this.valueWithCursor;
+
+            switch (this.state) {
+                case "error":
+                    return `${title.trim()}\n${color.yellow(S_BAR)}  ${value}\n${color.yellow(
+                        S_BAR_END,
+                    )}  ${color.yellow(this.error)}\n`;
+                case "submit":
+                    return `${title}${color.gray(S_BAR)}  ${color.dim(this.value || opts.placeholder)}`;
+                case "cancel":
+                    return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+                        color.dim(this.value ?? ""),
+                    )}${this.value?.trim() ? "\n" + color.gray(S_BAR) : ""}`;
+                default:
+                    return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
+            }
+        },
+    }).prompt();
+};
+
+export interface PasswordOptions {
+    message: string;
+    mask?: string;
+    validate?: (value: string) => string | void;
+}
+export const password = (opts: PasswordOptions) => {
+    return new PasswordPrompt({
+        validate: opts.validate,
+        mask: opts.mask ?? S_PASSWORD_MASK,
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+            const value = this.valueWithCursor;
+            const masked = this.masked;
+
+            switch (this.state) {
+                case "error":
+                    return `${title.trim()}\n${color.yellow(S_BAR)}  ${masked}\n${color.yellow(
+                        S_BAR_END,
+                    )}  ${color.yellow(this.error)}\n`;
+                case "submit":
+                    return `${title}${color.gray(S_BAR)}  ${color.dim(masked)}`;
+                case "cancel":
+                    return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(masked ?? ""))}${
+                        masked ? "\n" + color.gray(S_BAR) : ""
+                    }`;
+                default:
+                    return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
+            }
+        },
+    }).prompt();
+};
+
+export interface ConfirmOptions {
+    message: string;
+    active?: string;
+    inactive?: string;
+    initialValue?: boolean;
+}
+export const confirm = (opts: ConfirmOptions) => {
+    const active = opts.active ?? "Yes";
+    const inactive = opts.inactive ?? "No";
+    return new ConfirmPrompt({
+        active,
+        inactive,
+        initialValue: opts.initialValue ?? true,
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+            const value = this.value ? active : inactive;
+
+            switch (this.state) {
+                case "submit":
+                    return `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
+                case "cancel":
+                    return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(value))}\n${color.gray(S_BAR)}`;
+                default: {
+                    return `${title}${color.cyan(S_BAR)}  ${
+                        this.value
+                            ? `${color.green(S_RADIO_ACTIVE)} ${active}`
+                            : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(active)}`
+                    } ${color.dim("/")} ${
+                        !this.value
+                            ? `${color.green(S_RADIO_ACTIVE)} ${inactive}`
+                            : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(inactive)}`
+                    }\n${color.cyan(S_BAR_END)}\n`;
+                }
+            }
+        },
+    }).prompt() as Promise<boolean | symbol>;
+};
+
+type Primitive = Readonly<string | boolean | number>;
+
+type Option<Value> = Value extends Primitive
+    ? { value: Value; label?: string; hint?: string }
+    : { value: Value; label: string; hint?: string };
+
+export interface SelectOptions<Value> {
+    message: string;
+    options: Option<Value>[];
+    initialValue?: Value;
+    maxItems?: number;
+}
+
+export const select = <Value>(opts: SelectOptions<Value>) => {
+    const opt = (option: Option<Value>, state: "inactive" | "active" | "selected" | "cancelled") => {
+        const label = option.label ?? String(option.value);
+        switch (state) {
+            case "selected":
+                return color.dim(label);
+            case "active":
+                return `${color.green(S_RADIO_ACTIVE)} ${label} ${option.hint ? color.dim(`(${option.hint})`) : ""}`;
+            case "cancelled":
+                return color.strikethrough(color.dim(label));
+            default:
+                return `${color.dim(S_RADIO_INACTIVE)} ${color.dim(label)}`;
+        }
+    };
+
+    return new SelectPrompt({
+        options: opts.options,
+        initialValue: opts.initialValue,
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+
+            switch (this.state) {
+                case "submit":
+                    return `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], "selected")}`;
+                case "cancel":
+                    return `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], "cancelled")}\n${color.gray(S_BAR)}`;
+                default: {
+                    return `${title}${color.cyan(S_BAR)}  ${limitOptions({
+                        cursor: this.cursor,
+                        options: this.options,
+                        maxItems: opts.maxItems,
+                        style: (item, active) => opt(item, active ? "active" : "inactive"),
+                    }).join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+                }
+            }
+        },
+    }).prompt() as Promise<Value | symbol>;
+};
+
+export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
+    const opt = (option: Option<Value>, state: "inactive" | "active" | "selected" | "cancelled" = "inactive") => {
+        const label = option.label ?? String(option.value);
+        if (state === "selected") {
+            return color.dim(label);
+        } else if (state === "cancelled") {
+            return color.strikethrough(color.dim(label));
+        } else if (state === "active") {
+            return `${color.bgCyan(color.gray(` ${option.value} `))} ${label} ${
+                option.hint ? color.dim(`(${option.hint})`) : ""
+            }`;
+        }
+        return `${color.gray(color.bgWhite(color.inverse(` ${option.value} `)))} ${label} ${
+            option.hint ? color.dim(`(${option.hint})`) : ""
+        }`;
+    };
+
+    return new SelectKeyPrompt({
+        options: opts.options,
+        initialValue: opts.initialValue,
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+
+            switch (this.state) {
+                case "submit":
+                    return `${title}${color.gray(S_BAR)}  ${opt(
+                        this.options.find((opt) => opt.value === this.value)!,
+                        "selected",
+                    )}`;
+                case "cancel":
+                    return `${title}${color.gray(S_BAR)}  ${opt(this.options[0], "cancelled")}\n${color.gray(S_BAR)}`;
+                default: {
+                    return `${title}${color.cyan(S_BAR)}  ${this.options
+                        .map((option, i) => opt(option, i === this.cursor ? "active" : "inactive"))
+                        .join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+                }
+            }
+        },
+    }).prompt() as Promise<Value | symbol>;
+};
+
+export interface MultiSelectOptions<Value> {
+    message: string;
+    options: Option<Value>[];
+    initialValues?: Value[];
+    maxItems?: number;
+    required?: boolean;
+    cursorAt?: Value;
+}
+export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
+    const opt = (
+        option: Option<Value>,
+        state: "inactive" | "active" | "selected" | "active-selected" | "submitted" | "cancelled",
+    ) => {
+        const label = option.label ?? String(option.value);
+        if (state === "active") {
+            return `${color.cyan(S_CHECKBOX_ACTIVE)} ${label} ${option.hint ? color.dim(`(${option.hint})`) : ""}`;
+        } else if (state === "selected") {
+            return `${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
+        } else if (state === "cancelled") {
+            return color.strikethrough(color.dim(label));
+        } else if (state === "active-selected") {
+            return `${color.green(S_CHECKBOX_SELECTED)} ${label} ${option.hint ? color.dim(`(${option.hint})`) : ""}`;
+        } else if (state === "submitted") {
+            return color.dim(label);
+        }
+        return `${color.dim(S_CHECKBOX_INACTIVE)} ${color.dim(label)}`;
+    };
+
+    return new MultiSelectPrompt({
+        options: opts.options,
+        initialValues: opts.initialValues,
+        required: opts.required ?? true,
+        cursorAt: opts.cursorAt,
+        validate(selected: Value[]) {
+            if (this.required && selected.length === 0)
+                return `Please select at least one option.\n${color.reset(
+                    color.dim(
+                        `Press ${color.gray(color.bgWhite(color.inverse(" space ")))} to select, ${color.gray(
+                            color.bgWhite(color.inverse(" enter ")),
+                        )} to submit`,
+                    ),
+                )}`;
+        },
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+
+            const styleOption = (option: Option<Value>, active: boolean) => {
+                const selected = this.value.includes(option.value);
+                if (active && selected) {
+                    return opt(option, "active-selected");
+                }
+                if (selected) {
+                    return opt(option, "selected");
+                }
+                return opt(option, active ? "active" : "inactive");
+            };
+
+            switch (this.state) {
+                case "submit": {
+                    return `${title}${color.gray(S_BAR)}  ${
+                        this.options
+                            .filter(({ value }) => this.value.includes(value))
+                            .map((option) => opt(option, "submitted"))
+                            .join(color.dim(", ")) || color.dim("none")
+                    }`;
+                }
+                case "cancel": {
+                    const label = this.options
+                        .filter(({ value }) => this.value.includes(value))
+                        .map((option) => opt(option, "cancelled"))
+                        .join(color.dim(", "));
+                    return `${title}${color.gray(S_BAR)}  ${label.trim() ? `${label}\n${color.gray(S_BAR)}` : ""}`;
+                }
+                case "error": {
+                    const footer = this.error
+                        .split("\n")
+                        .map((ln, i) => (i === 0 ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}` : `   ${ln}`))
+                        .join("\n");
+                    return (
+                        title +
+                        color.yellow(S_BAR) +
+                        "  " +
+                        limitOptions({
+                            options: this.options,
+                            cursor: this.cursor,
+                            maxItems: opts.maxItems,
+                            style: styleOption,
+                        }).join(`\n${color.yellow(S_BAR)}  `) +
+                        "\n" +
+                        footer +
+                        "\n"
+                    );
+                }
+                default: {
+                    return `${title}${color.cyan(S_BAR)}  ${limitOptions({
+                        options: this.options,
+                        cursor: this.cursor,
+                        maxItems: opts.maxItems,
+                        style: styleOption,
+                    }).join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+                }
+            }
+        },
+    }).prompt() as Promise<Value[] | symbol>;
+};
+
+export interface GroupMultiSelectOptions<Value> {
+    message: string;
+    options: Record<string, Option<Value>[]>;
+    initialValues?: Value[];
+    required?: boolean;
+    cursorAt?: Value;
+    selectableGroups?: boolean;
+}
+export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) => {
+    const selectableGroups = opts.selectableGroups ?? true;
+    const opt = (
+        option: Option<Value>,
+        state:
+            | "inactive"
+            | "active"
+            | "selected"
+            | "active-selected"
+            | "group-active"
+            | "group-active-selected"
+            | "submitted"
+            | "cancelled",
+        options: Option<Value>[] = [],
+    ) => {
+        const label = option.label ?? String(option.value);
+        const isItem = typeof (option as any).group === "string";
+        const next = isItem && (options[options.indexOf(option) + 1] ?? { group: true });
+        // @ts-ignore
+        const isLast = isItem && next.group === true;
+        const prefix = isItem ? `${isLast ? S_BAR_END : S_BAR} ` : "";
+
+        if (state === "active") {
+            return `${color.dim(prefix)}${color.cyan(S_CHECKBOX_ACTIVE)} ${label} ${
+                option.hint ? color.dim(`(${option.hint})`) : ""
+            }`;
+        } else if (state === "group-active") {
+            return `${prefix}${color.cyan(S_CHECKBOX_ACTIVE)} ${color.dim(label)}`;
+        } else if (state === "group-active-selected") {
+            return `${prefix}${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
+        } else if (state === "selected") {
+            return `${color.dim(prefix)}${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
+        } else if (state === "cancelled") {
+            return color.strikethrough(color.dim(label));
+        } else if (state === "active-selected") {
+            return `${color.dim(prefix)}${color.green(S_CHECKBOX_SELECTED)} ${label} ${
+                option.hint ? color.dim(`(${option.hint})`) : ""
+            }`;
+        } else if (state === "submitted") {
+            return color.dim(label);
+        }
+        return `${color.dim(prefix)}${isItem || selectableGroups ? color.dim(S_CHECKBOX_INACTIVE) : ""} ${color.dim(label)}`;
+    };
+
+    return new GroupMultiSelectPrompt({
+        options: opts.options,
+        initialValues: opts.initialValues,
+        required: opts.required ?? true,
+        cursorAt: opts.cursorAt,
+        selectableGroups: selectableGroups,
+        validate(selected: Value[]) {
+            if (this.required && selected.length === 0)
+                return `Please select at least one option.\n${color.reset(
+                    color.dim(
+                        `Press ${color.gray(color.bgWhite(color.inverse(" space ")))} to select, ${color.gray(
+                            color.bgWhite(color.inverse(" enter ")),
+                        )} to submit`,
+                    ),
+                )}`;
+        },
+        render() {
+            const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+
+            switch (this.state) {
+                case "submit": {
+                    return `${title}${color.gray(S_BAR)}  ${this.options
+                        .filter(({ value }) => this.value.includes(value))
+                        .map((option) => opt(option, "submitted"))
+                        .join(color.dim(", "))}`;
+                }
+                case "cancel": {
+                    const label = this.options
+                        .filter(({ value }) => this.value.includes(value))
+                        .map((option) => opt(option, "cancelled"))
+                        .join(color.dim(", "));
+                    return `${title}${color.gray(S_BAR)}  ${label.trim() ? `${label}\n${color.gray(S_BAR)}` : ""}`;
+                }
+                case "error": {
+                    const footer = this.error
+                        .split("\n")
+                        .map((ln, i) => (i === 0 ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}` : `   ${ln}`))
+                        .join("\n");
+                    return `${title}${color.yellow(S_BAR)}  ${this.options
+                        .map((option, i, options) => {
+                            const selected =
+                                this.value.includes(option.value) ||
+                                (option.group === true && this.isGroupSelected(`${option.value}`));
+                            const active = i === this.cursor;
+                            const groupActive =
+                                !active && typeof option.group === "string" && this.options[this.cursor].value === option.group;
+                            if (groupActive) {
+                                return opt(option, selected ? "group-active-selected" : "group-active", options);
+                            }
+                            if (active && selected) {
+                                return opt(option, "active-selected", options);
+                            }
+                            if (selected) {
+                                return opt(option, "selected", options);
+                            }
+                            return opt(option, active ? "active" : "inactive", options);
+                        })
+                        .join(`\n${color.yellow(S_BAR)}  `)}\n${footer}\n`;
+                }
+                default: {
+                    return `${title}${color.cyan(S_BAR)}  ${this.options
+                        .map((option, i, options) => {
+                            const selected =
+                                this.value.includes(option.value) ||
+                                (option.group === true && this.isGroupSelected(`${option.value}`));
+                            const active = i === this.cursor;
+                            const groupActive =
+                                !active && typeof option.group === "string" && this.options[this.cursor].value === option.group;
+                            if (groupActive) {
+                                return opt(option, selected ? "group-active-selected" : "group-active", options);
+                            }
+                            if (active && selected) {
+                                return opt(option, "active-selected", options);
+                            }
+                            if (selected) {
+                                return opt(option, "selected", options);
+                            }
+                            return opt(option, active ? "active" : "inactive", options);
+                        })
+                        .join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+                }
+            }
+        },
+    }).prompt() as Promise<Value[] | symbol>;
+};
+
+const strip = (str: string) => str.replace(ansiRegex(), "");
+export const note = (message = "", title = "") => {
+    const lines = `\n${message}\n`.split("\n");
+    const titleLen = strip(title).length;
+    const len =
+        Math.max(
+            lines.reduce((sum, ln) => {
+                ln = strip(ln);
+                return ln.length > sum ? ln.length : sum;
+            }, 0),
+            titleLen,
+        ) + 2;
+    const msg = lines
+        .map((ln) => `${color.gray(S_BAR)}  ${color.dim(ln)}${" ".repeat(len - strip(ln).length)}${color.gray(S_BAR)}`)
+        .join("\n");
+    process.stdout.write(
+        `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)}  ${color.reset(title)} ${color.gray(
+            S_BAR_H.repeat(Math.max(len - titleLen - 1, 1)) + S_CORNER_TOP_RIGHT,
+        )}\n${msg}\n${color.gray(S_CONNECT_LEFT + S_BAR_H.repeat(len + 2) + S_CORNER_BOTTOM_RIGHT)}\n`,
+    );
+};
+
+export const cancel = (message = "") => {
+    process.stdout.write(`${color.gray(S_BAR_END)}  ${color.red(message)}\n\n`);
+};
+
+export const intro = (title = "") => {
+    process.stdout.write(`${color.gray(S_BAR_START)}  ${title}\n`);
+};
+
+export const outro = (message = "") => {
+    process.stdout.write(`${color.gray(S_BAR)}\n${color.gray(S_BAR_END)}  ${message}\n\n`);
+};
+
+export type LogMessageOptions = {
+    symbol?: string;
+};
+export const log = {
+    message: (message = "", { symbol = color.gray(S_BAR) }: LogMessageOptions = {}) => {
+        const parts = [color.gray(S_BAR)];
+        if (message) {
+            const [firstLine, ...lines] = message.split("\n");
+            parts.push(`${symbol}  ${firstLine}`, ...lines.map((ln) => `${color.gray(S_BAR)}  ${ln}`));
+        }
+        process.stdout.write(`${parts.join("\n")}\n`);
+    },
+    info: (message: string) => {
+        log.message(message, { symbol: color.blue(S_INFO) });
+    },
+    success: (message: string) => {
+        log.message(message, { symbol: color.green(S_SUCCESS) });
+    },
+    step: (message: string) => {
+        log.message(message, { symbol: color.green(S_STEP_SUBMIT) });
+    },
+    warn: (message: string) => {
+        log.message(message, { symbol: color.yellow(S_WARN) });
+    },
+    /** alias for `log.warn()`. */
+    warning: (message: string) => {
+        log.warn(message);
+    },
+    error: (message: string) => {
+        log.message(message, { symbol: color.red(S_ERROR) });
+    },
+};
+
+export const spinner = () => {
+    const frames = unicode ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"];
+    const delay = unicode ? 80 : 120;
+
+    let unblock: () => void;
+    let loop: NodeJS.Timeout;
+    let isSpinnerActive: boolean = false;
+    let _message: string = "";
+
+    const handleExit = (code: number) => {
+        const msg = code > 1 ? "Something went wrong" : "Canceled";
+        if (isSpinnerActive) stop(msg, code);
+    };
+
+    const errorEventHandler = () => {
+        handleExit(2);
+    };
+    const signalEventHandler = () => {
+        handleExit(1);
+    };
+
+    const registerHooks = () => {
+        // Reference: https://nodejs.org/api/process.html#event-uncaughtexception
+        process.on("uncaughtExceptionMonitor", errorEventHandler);
+        // Reference: https://nodejs.org/api/process.html#event-unhandledrejection
+        process.on("unhandledRejection", errorEventHandler);
+        // Reference Signal Events: https://nodejs.org/api/process.html#signal-events
+        process.on("SIGINT", signalEventHandler);
+        process.on("SIGTERM", signalEventHandler);
+        process.on("exit", handleExit);
+    };
+
+    const clearHooks = () => {
+        process.removeListener("uncaughtExceptionMonitor", errorEventHandler);
+        process.removeListener("unhandledRejection", errorEventHandler);
+        process.removeListener("SIGINT", signalEventHandler);
+        process.removeListener("SIGTERM", signalEventHandler);
+        process.removeListener("exit", handleExit);
+    };
+
+    const start = (msg: string = ""): void => {
+        isSpinnerActive = true;
+        unblock = block();
+        _message = msg.replace(/\.+$/, "");
+        process.stdout.write(`${color.gray(S_BAR)}\n`);
+        let frameIndex = 0;
+        let dotsTimer = 0;
+        registerHooks();
+        loop = setInterval(() => {
+            const frame = color.magenta(frames[frameIndex]);
+            const loadingDots = ".".repeat(Math.floor(dotsTimer)).slice(0, 3);
+            process.stdout.write(cursor.move(-999, 0));
+            process.stdout.write(erase.down(1));
+            process.stdout.write(`${frame}  ${_message}${loadingDots}`);
+            frameIndex = frameIndex + 1 < frames.length ? frameIndex + 1 : 0;
+            dotsTimer = dotsTimer < frames.length ? dotsTimer + 0.125 : 0;
+        }, delay);
+    };
+
+    const stop = (msg: string = "", code: number = 0): void => {
+        _message = msg ?? _message;
+        isSpinnerActive = false;
+        clearInterval(loop);
+        const step = code === 0 ? color.green(S_STEP_SUBMIT) : code === 1 ? color.red(S_STEP_CANCEL) : color.red(S_STEP_ERROR);
+        process.stdout.write(cursor.move(-999, 0));
+        process.stdout.write(erase.down(1));
+        process.stdout.write(`${step}  ${_message}\n`);
+        clearHooks();
+        unblock();
+    };
+
+    const message = (msg: string = ""): void => {
+        _message = msg ?? _message;
+    };
+
+    return {
+        start,
+        stop,
+        message,
+    };
+};
+
+// Adapted from https://github.com/chalk/ansi-regex
+// @see LICENSE
+function ansiRegex() {
+    const pattern = [
+        "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+        "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+    ].join("|");
+
+    return new RegExp(pattern, "g");
+}
+
+export type PromptGroupAwaitedReturn<T> = {
+    [P in keyof T]: Exclude<Awaited<T[P]>, symbol>;
+};
+
+export interface PromptGroupOptions<T> {
+    /**
+     * Control how the group can be canceled
+     * if one of the prompts is canceled.
+     */
+    onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
+}
+
+type Prettify<T> = {
+    [P in keyof T]: T[P];
+} & {};
+
+export type PromptGroup<T> = {
+    [P in keyof T]: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>> }) => void | Promise<T[P] | void>;
+};
+
+/**
+ * Define a group of prompts to be displayed
+ * and return a results of objects within the group
+ */
+export const group = async <T>(
+    prompts: PromptGroup<T>,
+    opts?: PromptGroupOptions<T>,
+): Promise<Prettify<PromptGroupAwaitedReturn<T>>> => {
+    const results = {} as any;
+    const promptNames = Object.keys(prompts);
+
+    for (const name of promptNames) {
+        const prompt = prompts[name as keyof T];
+        const result = await prompt({ results })?.catch((e) => {
+            throw e;
+        });
+
+        // Pass the results to the onCancel function
+        // so the user can decide what to do with the results
+        // TODO: Switch to callback within core to avoid isCancel Fn
+        if (typeof opts?.onCancel === "function" && isCancel(result)) {
+            results[name] = "canceled";
+            opts.onCancel({ results });
+            continue;
+        }
+
+        results[name] = result;
+    }
+
+    return results;
+};
+
+export type Task = {
+    /**
+     * Task title
+     */
+    title: string;
+    /**
+     * Task function
+     */
+    task: (message: (string: string) => void) => string | Promise<string> | void | Promise<void>;
+
+    /**
+     * If enabled === false the task will be skipped
+     */
+    enabled?: boolean;
+};
+
+/**
+ * Define a group of tasks to be executed
+ */
+export const tasks = async (tasks: Task[]) => {
+    for (const task of tasks) {
+        if (task.enabled === false) continue;
+
+        const s = spinner();
+        s.start(task.title);
+        const result = await task.task(s.message);
+        s.stop(result || task.title);
+    }
+};

--- a/packages/clack-prompts/package.json
+++ b/packages/clack-prompts/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@svelte-add/clack-prompts",
+    "version": "0.9.0",
+    "type": "module",
+    "module": "./build/index.js",
+    "exports": {
+        ".": {
+            "types": "./build/index.d.ts",
+            "default": "./build/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "types": "./build/index.d.ts",
+    "bugs": "https://github.com/svelte-add/svelte-add/issues",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/svelte-add/svelte-add/tree/main/packages/clack-prompts"
+    },
+    "files": [
+        "build"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "@svelte-add/clack-core": "workspace:*",
+        "sisteransi": "^1.0.5"
+    },
+    "devDependencies": {
+        "picocolors": "^1.0.0",
+        "is-unicode-supported": "^1.3.0"
+    }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,6 @@
         "build"
     ],
     "devDependencies": {
-        "@clack/prompts": "^0.7.0",
         "commander": "^12.1.0",
         "picocolors": "^1.0.1",
         "preferred-pm": "^3.1.3"
@@ -25,6 +24,7 @@
     "dependencies": {
         "@svelte-add/ast-manipulation": "workspace:*",
         "@svelte-add/ast-tooling": "workspace:*",
+        "@svelte-add/clack-prompts": "workspace:*",
         "prettier": "^3.3.2",
         "prettier-plugin-svelte": "^3.2.4"
     },

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -3,7 +3,7 @@ import { commonFilePaths, directoryExists, fileExists } from "../files/utils.js"
 import { type PromptOption, booleanPrompt, selectPrompt, textPrompt, endPrompts } from "./prompts.js";
 import { executeCli, getPackageJson } from "./common.js";
 import { createEmptyWorkspace } from "./workspace.js";
-import { spinner } from "@clack/prompts";
+import { spinner } from "@svelte-add/clack-prompts";
 
 export type ProjectType = "svelte" | "kit";
 

--- a/packages/core/utils/dependencies.ts
+++ b/packages/core/utils/dependencies.ts
@@ -1,6 +1,6 @@
 import { selectPrompt } from "./prompts";
 import preferredPackageManager from "preferred-pm";
-import { spinner } from "@clack/prompts";
+import { spinner } from "@svelte-add/clack-prompts";
 import { executeCli } from "./common";
 
 export async function suggestInstallingDependencies(workingDirectory: string) {

--- a/packages/core/utils/prompts.ts
+++ b/packages/core/utils/prompts.ts
@@ -1,4 +1,4 @@
-import { cancel, intro, isCancel, outro, select, text, multiselect, note } from "@clack/prompts";
+import { cancel, intro, isCancel, outro, select, text, multiselect, note, groupMultiselect } from "@svelte-add/clack-prompts";
 
 type Primitive = Readonly<string | boolean | number>;
 export type PromptOption<Value> = Value extends Primitive
@@ -50,10 +50,21 @@ export async function textPrompt(question: string, placeholder: string = "", ini
 }
 
 export async function multiSelectPrompt<T>(question: string, options: PromptOption<T>[]) {
-    const value = await multiselect<PromptOption<T>[], T>({
+    const value = await multiselect<T>({
         message: question,
         options,
         required: false,
+    });
+
+    return cancelIfRequired(value);
+}
+
+export async function groupedMultiSelectPrompt<T>(question: string, options: Record<string, PromptOption<T>[]>) {
+    const value = await groupMultiselect<T>({
+        message: question,
+        options,
+        required: false,
+        selectableGroups: false,
     });
 
     return cancelIfRequired(value);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,35 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
 
+  packages/clack-core:
+    dependencies:
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.0.1
+      sisteransi:
+        specifier: ^1.0.5
+        version: 1.0.5
+    devDependencies:
+      wrap-ansi:
+        specifier: ^8.1.0
+        version: 8.1.0
+
+  packages/clack-prompts:
+    dependencies:
+      '@svelte-add/clack-core':
+        specifier: workspace:*
+        version: link:../clack-core
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.0.1
+      sisteransi:
+        specifier: ^1.0.5
+        version: 1.0.5
+    devDependencies:
+      is-unicode-supported:
+        specifier: ^1.3.0
+        version: 1.3.0
+
   packages/cli:
     dependencies:
       '@svelte-add/bootstrap':
@@ -189,6 +218,9 @@ importers:
       '@svelte-add/ast-tooling':
         specifier: workspace:*
         version: link:../ast-tooling
+      '@svelte-add/clack-prompts':
+        specifier: workspace:*
+        version: link:../clack-prompts
       prettier:
         specifier: ^3.3.2
         version: 3.3.2
@@ -196,9 +228,6 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(prettier@3.3.2)(svelte@4.2.18)
     devDependencies:
-      '@clack/prompts':
-        specifier: ^0.7.0
-        version: 0.7.0
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -2161,6 +2190,10 @@ packages:
 
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
 
   is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
@@ -5719,6 +5752,8 @@ snapshots:
       which-typed-array: 1.1.15
 
   is-typedarray@1.0.0: {}
+
+  is-unicode-supported@1.3.0: {}
 
   is-weakref@1.0.2:
     dependencies:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -94,6 +94,8 @@ for (const adder of adderFolders) {
 }
 
 export default [
+    getConfig("clack-core", false),
+    getConfig("clack-prompts", false),
     getConfig("ast-tooling", false),
     getConfig("ast-manipulation", false),
     getConfig("core", false),


### PR DESCRIPTION
 closes #410

This PR also adds `clack-core` and `clack-prompts` (which implements inactive group headers) to the repo as a temporary solution until https://github.com/bombshell-dev/clack/pull/199 is (hopefully!) merged.

Here's what the main CLI looks like now:
![img](https://i.imgur.com/cdFtavB.png)
Now that the selection is flat, we should also probably categorize them a bit differently and more specific as well, such as: CSS, DB, Markdown, etc.