### PR TITLE
fix: adder punctuation

### DIFF
--- a/.changeset/friendly-snakes-drop.md
+++ b/.changeset/friendly-snakes-drop.md
@@ -1,0 +1,6 @@
+---
+"@svelte-add/tailwindcss": patch
+"@svelte-add/bulma": patch
+---
+
+fix: adder punctuation

--- a/adders/bulma/config/adder.ts
+++ b/adders/bulma/config/adder.ts
@@ -6,7 +6,7 @@ export const adder = defineAdderConfig({
     metadata: {
         ...generateAdderInfo(pkg),
         name: "Bulma",
-        description: "The modern CSS framework that just works.",
+        description: "The modern CSS framework that just works",
         category: categories.styling,
         environments: { kit: true, svelte: true },
         website: {

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -6,7 +6,7 @@ export const adder = defineAdderConfig({
     metadata: {
         ...generateAdderInfo(pkg),
         name: "TailwindCSS",
-        description: "Rapidly build modern websites without ever leaving your HTML.",
+        description: "Rapidly build modern websites without ever leaving your HTML",
         category: categories.styling,
         environments: { svelte: true, kit: true },
         website: {


### PR DESCRIPTION
While testing #421 I saw that some adders had dot's at the end of the description and some did not. This unifies the description to be without a dot as this looks better in my opinion