### PR TITLE
feat: simplify cli usage `pnpm dlx svelte-add tailwindcss`

### DIFF
--- a/.changeset/curly-parrots-taste.md
+++ b/.changeset/curly-parrots-taste.md
@@ -1,0 +1,7 @@
+---
+"@svelte-add/website": minor
+"@svelte-add/core": minor
+"svelte-add": minor
+---
+
+feat: simplify cli usage

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ npx svelte-add@latest --path ./your-project
 If you want to install multiple adders at once, you can use this command:
 
 ```sh
-npx svelte-add@latest --adder bulma mdsvex
+npx svelte-add@latest bulma mdsvex
 ```
 
 You can also directly pass through options for each adder. Please refer to the website [this site](https://svelte-add.com) to generate such commands. Alternatively you can refer to the individual adder options.

--- a/packages/core/adder/options.ts
+++ b/packages/core/adder/options.ts
@@ -113,7 +113,7 @@ export function prepareAndParseCliOptions<Args extends OptionDefinition>(adderDe
     }
 
     if (multipleAdders) {
-        program.option("--adder <string...>", "List of adders to install");
+        program.argument("<adders...>", "List of adders to install");
     }
 
     const addersWithOptions = adderDetails.filter((x) => Object.keys(x.config.options).length > 0);
@@ -135,6 +135,11 @@ export function prepareAndParseCliOptions<Args extends OptionDefinition>(adderDe
 
     program.parse();
     const options = program.opts();
+
+    if (multipleAdders) {
+        options.adder = program.args;
+    }
+
     return options;
 }
 

--- a/packages/core/adder/options.ts
+++ b/packages/core/adder/options.ts
@@ -113,7 +113,7 @@ export function prepareAndParseCliOptions<Args extends OptionDefinition>(adderDe
     }
 
     if (multipleAdders) {
-        program.argument("<adders...>", "List of adders to install");
+        program.argument("[adders...]", "List of adders to install");
     }
 
     const addersWithOptions = adderDetails.filter((x) => Object.keys(x.config.options).length > 0);

--- a/packages/website/src/lib/Configurator.svelte
+++ b/packages/website/src/lib/Configurator.svelte
@@ -44,7 +44,7 @@
 
         if (multipleAdders) {
             const adderIds = Object.keys(args).join(" ");
-            command += `svelte-add@latest --adder ${adderIds}`;
+            command += `svelte-add@latest ${adderIds}`;
         } else {
             command += "@svelte-add/" + firstAdderId + "@latest";
         }


### PR DESCRIPTION
As suggested in #420 we are able to omit the `--adder` flag. This simplifies usage and makes the command shorter to remember.

You can now use
```
pnpm dlx svelte-add@latest tailwindcss bootstrap
```

instead of 
```
pnpm dlx svelte-add@latest --adder tailwindcss bootstrap
```