### PR TITLE
chore: `svelte-add` should not be a peer dep of itself

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,8 +22,7 @@
         "@svelte-add/mdsvex": "workspace:^",
         "@svelte-add/routify": "workspace:^",
         "@svelte-add/storybook": "workspace:^",
-        "@svelte-add/tailwindcss": "workspace:^",
-        "svelte-add": "workspace:^"
+        "@svelte-add/tailwindcss": "workspace:^"
     },
     "devDependencies": {
         "commander": "^12.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       '@svelte-add/tailwindcss':
         specifier: workspace:^
         version: link:../../adders/tailwindcss
-      svelte-add:
-        specifier: workspace:^
-        version: 'link:'
     devDependencies:
       commander:
         specifier: ^12.1.0


### PR DESCRIPTION
Should fix the major version bump in #430 