### PR TITLE
feat: display website documentation url in hint

### DIFF
--- a/.changeset/cyan-moose-beg.md
+++ b/.changeset/cyan-moose-beg.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+feat: display website documentation url in hint

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -218,7 +218,7 @@ async function askForAddersToApply<Args extends OptionDefinition>(
             options.push({
                 label: adderMetadata.name,
                 value: adderMetadata.id,
-                hint: adderMetadata.description,
+                hint: adderMetadata.website?.documentation || "",
             });
         }
 


### PR DESCRIPTION
this will need a changeset, but I didn't know if you wanted to add it as patch or minor, so feel free to add one with the bot