### PR TITLE
feat: custom ordered adders

### DIFF
--- a/.changeset/rude-bananas-mix.md
+++ b/.changeset/rude-bananas-mix.md
@@ -1,0 +1,9 @@
+---
+"@svelte-add/testing-library": minor
+"@svelte-add/website": minor
+"@svelte-add/config": minor
+"@svelte-add/core": minor
+"svelte-add": minor
+---
+
+feat: custom ordered adders

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ pnpm changeset
 -   add the new adders as a peer dependency to `svelte-add`
 -   set an appropriate package name & version version in `package.json`
 -   run `pnpm install` (ignore the warnings)
+-   add your adder to one of the categories in [`./packages/config/adders/official.ts`](./packages/config/adders/official.ts)
 -   start development server `pnpm build:dev`
 -   once you have finished developing your adder, don't forget to generate the readme `pnpm utils:readmes` & the `package.json` with `pnpm utils:packages`
 

--- a/adders/bootstrap/config/adder.ts
+++ b/adders/bootstrap/config/adder.ts
@@ -12,7 +12,7 @@ export const adder = defineAdderConfig({
         website: {
             logo: "./bootstrap.svg",
             keywords: ["bootstrap", "css", "sass", "scss"],
-            documentation: "https://getbootstrap.com/docs/",
+            documentation: "https://getbootstrap.com/docs",
         },
     },
     options,

--- a/adders/bootstrap/config/adder.ts
+++ b/adders/bootstrap/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options.js";
 import type { HtmlAstEditor, JsAstEditor } from "@svelte-add/core/adder/config.js";
@@ -8,7 +8,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "Bootstrap",
         description: "Build fast, responsive sites with Bootstrap",
-        category: categories.css,
         environments: { kit: true, svelte: true },
         website: {
             logo: "./bootstrap.svg",

--- a/adders/bulma/config/adder.ts
+++ b/adders/bulma/config/adder.ts
@@ -11,7 +11,7 @@ export const adder = defineAdderConfig({
         website: {
             logo: "./bulma.svg",
             keywords: ["bulma", "css", "sass", "scss"],
-            documentation: "https://bulma.io/documentation/",
+            documentation: "https://bulma.io/documentation",
         },
     },
     options,

--- a/adders/bulma/config/adder.ts
+++ b/adders/bulma/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options.js";
 
@@ -7,7 +7,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "Bulma",
         description: "The modern CSS framework that just works",
-        category: categories.css,
         environments: { kit: true, svelte: true },
         website: {
             logo: "./bulma.svg",

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options";
 
@@ -13,7 +13,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "Drizzle",
         description: "Headless ORM for NodeJS, TypeScript and JavaScript",
-        category: categories.db,
         environments: { svelte: false, kit: true },
         website: {
             logo: "./drizzle.svg",

--- a/adders/mdsvex/config/adder.ts
+++ b/adders/mdsvex/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options";
 
@@ -7,7 +7,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "mdsvex",
         description: "svelte in markdown",
-        category: categories.markdown,
         environments: { svelte: true, kit: true },
         website: {
             logo: "./mdsvex.svg",

--- a/adders/routify/config/adder.ts
+++ b/adders/routify/config/adder.ts
@@ -11,7 +11,7 @@ export const adder = defineAdderConfig({
         website: {
             logo: "./routify.svg",
             keywords: ["routify", "svelte", "router"],
-            documentation: "https://routify.dev/",
+            documentation: "https://routify.dev",
         },
     },
     options,

--- a/adders/routify/config/adder.ts
+++ b/adders/routify/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options";
 
@@ -7,7 +7,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "routify",
         description: "The Router that Grows With You",
-        category: categories.tools,
         environments: { svelte: true, kit: false },
         website: {
             logo: "./routify.svg",

--- a/adders/storybook/config/adder.ts
+++ b/adders/storybook/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options.js";
 
@@ -7,7 +7,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "Storybook",
         description: "Build UIs without the grunt work",
-        category: categories.tools,
         environments: { kit: true, svelte: true },
         website: {
             logo: "./storybook.svg",

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -1,4 +1,4 @@
-import { categories, defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options";
 
@@ -7,7 +7,6 @@ export const adder = defineAdderConfig({
         ...generateAdderInfo(pkg),
         name: "TailwindCSS",
         description: "Rapidly build modern websites without ever leaving your HTML",
-        category: categories.css,
         environments: { svelte: true, kit: true },
         website: {
             logo: "./tailwindcss.svg",

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -11,7 +11,7 @@ export const adder = defineAdderConfig({
         website: {
             logo: "./tailwindcss.svg",
             keywords: ["tailwind", "postcss", "autoprefixer"],
-            documentation: "https://tailwindcss.com/docs/",
+            documentation: "https://tailwindcss.com/docs",
         },
     },
     options,

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
-import { remoteControl, executeAdders } from "@svelte-add/core/internal";
+import { remoteControl, executeAdders, prompts } from "@svelte-add/core/internal";
 import { getAdderList } from "./website";
 import type { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
 import pkg from "./package.json";
 import type { Question } from "@svelte-add/core/adder/options";
-import type { AdderDetails, ExecutingAdderInfo } from "@svelte-add/core/adder/execute";
+import type { AdderDetails, AddersToApplySelectorParams, ExecutingAdderInfo } from "@svelte-add/core/adder/execute";
+import { adderCategories, categories } from "@svelte-add/config";
+import type { CategoryKeys } from "@svelte-add/config";
 
 void executeCli();
 
@@ -25,9 +27,38 @@ async function executeCli() {
         version: pkg.version,
     };
 
-    await executeAdders(adderDetails, executingAdderInfo);
+    await executeAdders(adderDetails, executingAdderInfo, undefined, selectAddersToApply);
 
     remoteControl.disable();
+}
+
+type AdderOption = { value: string; label: string; hint: string };
+async function selectAddersToApply({ projectType, addersMetadata }: AddersToApplySelectorParams) {
+    const promptOptions: Record<string, AdderOption[]> = {};
+
+    for (const [categoryId, adderIds] of Object.entries(adderCategories)) {
+        const categoryDetails = categories[categoryId as CategoryKeys];
+        const options: AdderOption[] = [];
+        const adders = addersMetadata.filter((x) => adderIds.includes(x.id));
+
+        for (const adder of adders) {
+            // if we detected a kit project, and the adder is not available for kit, ignore it.
+            if (projectType === "kit" && !adder.environments.kit) continue;
+            // if we detected a svelte project, and the adder is not available for svelte, ignore it.
+            if (projectType === "svelte" && !adder.environments.svelte) continue;
+
+            options.push({
+                label: adder.name,
+                value: adder.id,
+                hint: adder.website?.documentation || "",
+            });
+        }
+
+        promptOptions[categoryDetails.name] = options;
+    }
+    const selectedAdders = await prompts.groupedMultiSelectPrompt("What would you like to add to your project?", promptOptions);
+
+    return selectedAdders;
 }
 
 async function getAdderConfig(name: string) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
         "build"
     ],
     "dependencies": {
+        "@svelte-add/config": "workspace:^",
         "@svelte-add/core": "workspace:*"
     },
     "peerDependencies": {

--- a/packages/cli/website.ts
+++ b/packages/cli/website.ts
@@ -1,11 +1,9 @@
 import type { AdderConfig } from "@svelte-add/core/adder/config";
 import type { Question } from "@svelte-add/core/adder/options";
+import { adderIds } from "@svelte-add/config";
 
 export function getAdderList(): string[] {
-    // @ts-expect-error The list is assembled during build and injected by rollup.
-    // If you don't see all required adders, please restart your dev server.
-
-    return ADDER_LIST as string[];
+    return adderIds;
 }
 
 export async function getAdderConfig(name: string) {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,3 @@
+# @svelte-add/config
+
+This package provides configurations for adders and categories. This package also includes community adders.

--- a/packages/config/adders/community.ts
+++ b/packages/config/adders/community.ts
@@ -7,11 +7,4 @@ export type CommunityAdder = {
 
 export type CommunityAdders = CommunityAdder[];
 
-export const communityAdders: CommunityAdders = [
-    {
-        id: "test",
-        displayName: "Test",
-        description: "Test description",
-        package: "@test/setup",
-    },
-];
+export const communityAdders: CommunityAdders = [];

--- a/packages/config/adders/community.ts
+++ b/packages/config/adders/community.ts
@@ -1,0 +1,17 @@
+export type CommunityAdder = {
+    id: string;
+    displayName: string;
+    description: string;
+    package: string;
+};
+
+export type CommunityAdders = CommunityAdder[];
+
+export const communityAdders: CommunityAdders = [
+    {
+        id: "test",
+        displayName: "Test",
+        description: "Test description",
+        package: "@test/setup",
+    },
+];

--- a/packages/config/adders/official.ts
+++ b/packages/config/adders/official.ts
@@ -1,0 +1,10 @@
+import type { AdderCategories } from "../categories";
+
+export const adderCategories: AdderCategories = {
+    css: ["tailwindcss", "bulma", "bootstrap"],
+    db: ["drizzle"],
+    markdown: ["mdsvex"],
+    tools: ["storybook", "routify"],
+};
+
+export const adderIds = Object.values(adderCategories).flatMap((x) => x);

--- a/packages/config/categories.ts
+++ b/packages/config/categories.ts
@@ -5,13 +5,9 @@ export type CategoryInfo = {
 };
 
 export type CategoryKeys = "css" | "tools" | "db" | "markdown";
-export type CategoryDetails = {
-    [K in CategoryKeys]: CategoryInfo;
-};
+export type CategoryDetails = Record<CategoryKeys, CategoryInfo>;
 
-export type AdderCategories = {
-    [K in CategoryKeys]: string[];
-};
+export type AdderCategories = Record<CategoryKeys, string[]>;
 
 export const categories: CategoryDetails = {
     css: {

--- a/packages/config/categories.ts
+++ b/packages/config/categories.ts
@@ -3,9 +3,14 @@ export type CategoryInfo = {
     name: string;
     description: string;
 };
+
 export type CategoryKeys = "css" | "tools" | "db" | "markdown";
 export type CategoryDetails = {
     [K in CategoryKeys]: CategoryInfo;
+};
+
+export type AdderCategories = {
+    [K in CategoryKeys]: string[];
 };
 
 export const categories: CategoryDetails = {

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -1,0 +1,5 @@
+import { adderIds, adderCategories } from "./adders/official.js";
+import { categories, type CategoryKeys, type CategoryInfo } from "./categories.js";
+import { communityAdders } from "./adders/community.js";
+
+export { adderIds, categories, adderCategories, communityAdders, type CategoryKeys, type CategoryInfo };

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@svelte-add/config",
+    "version": "1.0.0",
+    "license": "MIT",
+    "exports": {
+        ".": {
+            "types": "./build/index.d.ts",
+            "default": "./build/index.js"
+        }
+    },
+    "type": "module",
+    "devDependencies": {},
+    "bugs": "https://github.com/svelte-add/svelte-add/issues",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/svelte-add/svelte-add/tree/main/projects/config"
+    },
+    "keywords": []
+}

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -1,7 +1,6 @@
 import * as remoteControl from "./remoteControl.js";
 import { executeAdder } from "./execute.js";
 import type { CssAstEditor, HtmlAstEditor, JsAstEditor, SvelteAstEditor } from "@svelte-add/ast-manipulation";
-import type { CategoryInfo } from "./categories.js";
 import type { OptionDefinition, OptionValues, Question } from "./options.js";
 import type { FileTypes } from "../files/processors.js";
 import type { Workspace } from "../utils/workspace.js";
@@ -30,7 +29,6 @@ export type AdderConfigMetadata = {
     version: string;
     name: string;
     description: string;
-    category: CategoryInfo;
     environments: AdderConfigEnvironments;
     website?: WebsiteMetadata;
 };

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -118,8 +118,8 @@ async function executePlan<Args extends OptionDefinition>(
     // create project if required
     if (executionPlan.createProject) {
         const cwd = executionPlan.commonCliOptions.path ?? executionPlan.workingDirectory;
-        const supportKit = adderDetails.reduce((value, x) => value || x.config.metadata.environments.kit, false);
-        const supportSvelte = adderDetails.reduce((value, x) => value || x.config.metadata.environments.svelte, false);
+        const supportKit = adderDetails.some((x) => x.config.metadata.environments.kit);
+        const supportSvelte = adderDetails.some((x) => x.config.metadata.environments.svelte);
         const { projectCreated, directory } = await createProject(cwd, supportKit, supportSvelte);
         if (!projectCreated) return;
         executionPlan.workingDirectory = directory;

--- a/packages/core/adder/nextSteps.ts
+++ b/packages/core/adder/nextSteps.ts
@@ -33,5 +33,5 @@ export function displayNextSteps<Args extends OptionDefinition>(
             return adderMessage;
         })
         .join("\n\n");
-    messagePrompt("Next steps", allAddersMessage);
+    if (allAddersMessage) messagePrompt("Next steps", allAddersMessage);
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,15 +1,5 @@
 import { defineAdderConfig, defineAdderTests, defineAdder, defineAdderOptions, defineAdderChecks } from "./adder/config.js";
 import { generateAdderInfo } from "./adder/execute.js";
-import { categories } from "./adder/categories.js";
 import { executeCli } from "./utils/common.js";
 
-export {
-    defineAdderConfig,
-    generateAdderInfo,
-    defineAdder,
-    defineAdderTests,
-    defineAdderOptions,
-    defineAdderChecks,
-    executeCli,
-    categories,
-};
+export { defineAdderConfig, generateAdderInfo, defineAdder, defineAdderTests, defineAdderOptions, defineAdderChecks, executeCli };

--- a/packages/core/internal.ts
+++ b/packages/core/internal.ts
@@ -1,11 +1,10 @@
 import * as remoteControl from "./adder/remoteControl.js";
-import { executeAdder, executeAdders, determineWorkingDirectory } from "./adder/execute.js";
+import { executeAdder, executeAdders, determineWorkingDirectory, type AddersToApplySelectorParams } from "./adder/execute.js";
 import { createOrUpdateFiles } from "./files/processors.js";
 import { createEmptyWorkspace, populateWorkspaceDetails } from "./utils/workspace.js";
-import { type PromptOption, endPrompts, multiSelectPrompt, textPrompt, startPrompts } from "./utils/prompts.js";
 import { suggestInstallingDependencies } from "./utils/dependencies.js";
-import { groupBy } from "./utils/common.js";
 import { availableCliOptions, type AvailableCliOptions } from "./adder/options.js";
+import * as prompts from "./utils/prompts.js";
 
 export {
     remoteControl,
@@ -15,13 +14,9 @@ export {
     executeAdders,
     populateWorkspaceDetails,
     determineWorkingDirectory,
-    endPrompts,
-    multiSelectPrompt,
-    textPrompt,
-    startPrompts,
+    prompts,
     suggestInstallingDependencies,
-    groupBy,
     availableCliOptions,
 };
 
-export type { PromptOption, AvailableCliOptions };
+export type { AvailableCliOptions, AddersToApplySelectorParams };

--- a/packages/core/utils/common.ts
+++ b/packages/core/utils/common.ts
@@ -72,17 +72,3 @@ export async function executeCli(
         });
     });
 }
-
-export function groupBy<Key, Value>(list: Value[], keyGetter: (input: Value) => Key) {
-    const map = new Map<Key, Value[]>();
-    list.forEach((item) => {
-        const key = keyGetter(item);
-        const collection = map.get(key);
-        if (!collection) {
-            map.set(key, [item]);
-        } else {
-            collection.push(item);
-        }
-    });
-    return map;
-}

--- a/packages/testing-library/utils/test-cases.ts
+++ b/packages/testing-library/utils/test-cases.ts
@@ -7,7 +7,7 @@ import { startDevServer, stopDevServer } from "./dev-server";
 import { startBrowser, stopBrowser } from "./browser-control";
 import { getTemplatesDirectory, installDependencies, prepareWorkspaceWithTemplate, saveOptionsFile } from "./workspace";
 import { runAdder } from "./adder";
-import { textPrompt } from "@svelte-add/core/internal";
+import { prompts } from "@svelte-add/core/internal";
 import * as Throttle from "promise-parallel-throttle";
 import type { AdderWithoutExplicitArgs } from "@svelte-add/core/adder/config";
 import type { TestOptions } from "..";
@@ -79,7 +79,7 @@ export async function runAdderTests(
         if (errorOcurred) throw new Error("Dev server failed to start correctly. Vite errors present");
 
         if (testOptions.pauseExecutionAfterBrowser) {
-            await textPrompt("Browser opened! Press any key to continue!");
+            await prompts.textPrompt("Browser opened! Press any key to continue!");
         }
 
         await runTests(page, adder, options);

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -25,6 +25,7 @@
     },
     "dependencies": {
         "@svelte-add/core": "workspace:^",
+        "@svelte-add/config": "workspace:^",
         "svelte-add": "workspace:^"
     }
 }

--- a/packages/website/src/routes/categories/[category]/+page.server.ts
+++ b/packages/website/src/routes/categories/[category]/+page.server.ts
@@ -1,7 +1,6 @@
 import { getAdderInfos } from "$lib/adder.js";
-import { categories } from "@svelte-add/core";
+import { categories, type CategoryKeys } from "@svelte-add/config";
 import { availableCliOptions } from "@svelte-add/core/internal";
-import type { CategoryKeys } from "../../../../../core/adder/categories.js";
 
 export async function load({ params }) {
     const infos = await getAdderInfos(params.category);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@svelte-add/bulma':
         specifier: workspace:^
         version: link:../../adders/bulma
+      '@svelte-add/config':
+        specifier: workspace:^
+        version: link:../config
       '@svelte-add/core':
         specifier: workspace:*
         version: link:../core
@@ -207,6 +210,8 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+
+  packages/config: {}
 
   packages/core:
     dependencies:
@@ -296,6 +301,9 @@ importers:
 
   packages/website:
     dependencies:
+      '@svelte-add/config':
+        specifier: workspace:^
+        version: link:../config
       '@svelte-add/core':
         specifier: workspace:^
         version: link:../core

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,6 @@ const adderFolders = fs
     .readdirSync("./adders/", { withFileTypes: true })
     .filter((item) => item.isDirectory())
     .map((item) => item.name);
-const adderNamesAsString = adderFolders.map((x) => `"${x}"`);
 
 /** @type {import("rollup").RollupOptions[]} */
 const dtsConfigs = [];
@@ -56,7 +55,6 @@ function getConfig(project, isAdder) {
             dir: outDir,
             format: "esm",
             sourcemap: true,
-            intro: project === "cli" ? `const ADDER_LIST = [${adderNamesAsString.join(",")}];` : undefined,
         },
         external,
         plugins: [
@@ -99,6 +97,7 @@ export default [
     getConfig("clack-prompts", false),
     getConfig("ast-tooling", false),
     getConfig("ast-manipulation", false),
+    getConfig("config", false),
     getConfig("core", false),
     ...adderConfigs,
     getConfig("cli", false),


### PR DESCRIPTION
This prepares `svelte-add` to provide a non-alphabetical order of adders in the cli and the website. Additionally, this prepares a few types and files to support community adders, but no functionality at this point.

Notable changes
* There is now a package `@svelte-add/config` which provides the following
  * A list of categories extracted from `@svelte-add/core` (core was never really using the categories, only the cli and the website)
  * A mapping from categories to adders present in that category. The order the adders are written in this config, will be the order they will be displayed in the cli and on the website.
  * A list of community adders (not in use at this point, but I already added them since I was already generating this new package)
* Changed responsibilities for handling of categories
  * `@svelte-add/config` is now responsible for this
  * Now that we define categories and the adder display orders in a new package, we need to make sure to bump only required dependencies when adding new categories or changing display orders.
  * That's why `@svelte-add/config` is only used by `svelte-add` and `@svelte-add/website`. This avoids unnecessary bumping of `@svelte-add/core`
* Changed responsibilities for selecting adders to be applied. This was previously done by `@svelte-add/core` and is now done by `svelte-add` as this is the only place this was used. See version bumping reasoning before
* Rollup is not dynamically injecting a list of adders into `svelte-add` anymore. The list of supported adders is now determined by the adder category mapping.

Other changes
* Updated the ordering of the adders in the CSS category as discussed

To be discussed
* Naming of `@svelte-add/config` could be changed. 

Blocks #432 