### PR TITLE
fix: do not display empty categories in cli

### DIFF
--- a/.changeset/empty-pillows-bathe.md
+++ b/.changeset/empty-pillows-bathe.md
@@ -1,0 +1,5 @@
+---
+"svelte-add": patch
+---
+
+fix: do not display empty categories in cli

--- a/.changeset/odd-actors-buy.md
+++ b/.changeset/odd-actors-buy.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/testing-library": patch
+---
+
+chore: remove unneeded `svelte-add` dependency

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -54,7 +54,9 @@ async function selectAddersToApply({ projectType, addersMetadata }: AddersToAppl
             });
         }
 
-        promptOptions[categoryDetails.name] = options;
+        if (options.length > 0) {
+            promptOptions[categoryDetails.name] = options;
+        }
     }
     const selectedAdders = await prompts.groupedMultiSelectPrompt("What would you like to add to your project?", promptOptions);
 

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -16,8 +16,7 @@
         "@svelte-add/ast-tooling": "workspace:^",
         "@svelte-add/core": "workspace:^",
         "playwright": "^1.44.1",
-        "create-svelte": "^6.3.0",
-        "svelte-add": "workspace:^"
+        "create-svelte": "^6.3.0"
     },
     "devDependencies": {
         "promise-parallel-throttle": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,9 +273,6 @@ importers:
       playwright:
         specifier: ^1.44.1
         version: 1.44.1
-      svelte-add:
-        specifier: workspace:^
-        version: link:../cli
     devDependencies:
       promise-parallel-throttle:
         specifier: ^3.5.0


### PR DESCRIPTION
Closes #432 

To reproduce the issue
```
pnpm dlx svelte-add@2.2.1
```

create a new svelte project (js  / ts does not matter). You will see the empty Database category.

After this fix, this will not happen anymore