### PR TITLE
fix: `docker-compose.yml` intendation

### DIFF
--- a/.changeset/cyan-dogs-give.md
+++ b/.changeset/cyan-dogs-give.md
@@ -2,4 +2,4 @@
 "@svelte-add/drizzle": patch
 ---
 
-fix: `docker-compose.yml` intendation
+fix: `docker-compose.yml` indentation

--- a/.changeset/cyan-dogs-give.md
+++ b/.changeset/cyan-dogs-give.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/drizzle": patch
+---
+
+fix: `docker-compose.yml` intendation

--- a/.changeset/quiet-toes-look.md
+++ b/.changeset/quiet-toes-look.md
@@ -2,4 +2,4 @@
 "@svelte-add/core": minor
 ---
 
-feat: provide dedent utility
+feat: provide `dedent` utility

--- a/.changeset/quiet-toes-look.md
+++ b/.changeset/quiet-toes-look.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": minor
+---
+
+feat: provide dedent utility

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -1,4 +1,4 @@
-import { defineAdderConfig, generateAdderInfo } from "@svelte-add/core";
+import { defineAdderConfig, generateAdderInfo, dedent } from "@svelte-add/core";
 import pkg from "../package.json";
 import { options } from "./options";
 
@@ -118,33 +118,35 @@ export const adder = defineAdderConfig({
                 const imageName = options.database === "mysql" ? "mysql" : "postgres";
                 const port = PORTS[options.database];
 
-                content = `
+                const USER = "root";
+                const PASSWORD = "mysecretpassword";
+                const DB_NAME = "local";
+
+                let dbSpecificContent = "";
+                if (options.mysql === "mysql2") {
+                    dbSpecificContent = `
+                      MYSQL_ROOT_PASSWORD: ${PASSWORD}
+                      MYSQL_DATABASE: ${DB_NAME}
+                `;
+                }
+                if (options.postgresql === "postgres.js") {
+                    dbSpecificContent = `
+                      POSTGRES_USER: ${USER}
+                      POSTGRES_PASSWORD: ${PASSWORD}
+                      POSTGRES_DB: ${DB_NAME}
+                `;
+                }
+
+                content = dedent`
                 services:
                   db:
                     image: ${imageName}
                     restart: always
                     ports:
                       - ${port}:${port}
-                    environment:
+                    environment: ${dbSpecificContent}
                 `;
 
-                const USER = "root";
-                const PASSWORD = "mysecretpassword";
-                const DB_NAME = "local";
-
-                if (options.mysql === "mysql2") {
-                    content += `
-                      MYSQL_ROOT_PASSWORD: ${PASSWORD}
-                      MYSQL_DATABASE: ${DB_NAME}
-                `;
-                }
-                if (options.postgresql === "postgres.js") {
-                    content += `
-                      POSTGRES_USER: ${USER}
-                      POSTGRES_PASSWORD: ${PASSWORD}
-                      POSTGRES_DB: ${DB_NAME}
-                `;
-                }
                 return content;
             },
         },

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,15 @@
 import { defineAdderConfig, defineAdderTests, defineAdder, defineAdderOptions, defineAdderChecks } from "./adder/config.js";
 import { generateAdderInfo } from "./adder/execute.js";
 import { executeCli } from "./utils/common.js";
+import dedent from "dedent";
 
-export { defineAdderConfig, generateAdderInfo, defineAdder, defineAdderTests, defineAdderOptions, defineAdderChecks, executeCli };
+export {
+    defineAdderConfig,
+    generateAdderInfo,
+    defineAdder,
+    defineAdderTests,
+    defineAdderOptions,
+    defineAdderChecks,
+    executeCli,
+    dedent,
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "devDependencies": {
         "@svelte-add/clack-prompts": "workspace:*",
         "commander": "^12.1.0",
+        "dedent": "^1.5.3",
         "picocolors": "^1.0.1",
         "preferred-pm": "^3.1.3"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      dedent:
+        specifier: ^1.5.3
+        version: 1.5.3
       picocolors:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1476,6 +1479,14 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -4970,6 +4981,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  dedent@1.5.3: {}
 
   deep-extend@0.6.0: {}
 


### PR DESCRIPTION
Closes #418 

The original issue is only reproducible for me, when creating a new project via our cli, outside the monorepo. The `docker-compose.yml` was intended way to much in that case, and contained a new line that shouldn't be there.

This does not happen on pre-existing projects, as we try to run the locally installed prettier instance and try to format that file.