### PR TITLE
chore: remove `prettier` as a dependency

### DIFF
--- a/.changeset/selfish-dots-yell.md
+++ b/.changeset/selfish-dots-yell.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+chore: removed `prettier` as a direct dependency and use the project's local installation of `prettier` for formatting

--- a/.changeset/wise-coins-hammer.md
+++ b/.changeset/wise-coins-hammer.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/ast-tooling": patch
+---
+
+fix: empty style and script tags are no longer included

--- a/adders/drizzle/config/tests.ts
+++ b/adders/drizzle/config/tests.ts
@@ -65,7 +65,7 @@ export const tests = defineAdderTests({
             contentType: "text",
             condition: ({ kit }) => kit.installed,
             content: ({ content }) => {
-                return content.replace("strict: true,", "");
+                return content.replace("strict: true", "");
             },
         },
         {

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -140,19 +140,25 @@ export function serializeSvelteFile(asts: SvelteAst) {
     const css = serializePostcss(cssAst);
     const newScriptValue = serializeScript(jsAst);
 
-    const scriptTag = new Element("script", {}, undefined, ElementType.ElementType.Script);
-    for (const child of scriptTag.children) {
-        removeElement(child);
-    }
-    appendChild(scriptTag, new Text(newScriptValue));
-    appendChild(htmlAst, scriptTag);
+    if (newScriptValue.length > 0) {
+        const scriptTag = new Element("script", {}, undefined, ElementType.ElementType.Script);
+        for (const child of scriptTag.children) {
+            removeElement(child);
+        }
 
-    const styleTag = new Element("style", {}, undefined, ElementType.ElementType.Style);
-    for (const child of styleTag.children) {
-        removeElement(child);
+        appendChild(scriptTag, new Text(newScriptValue));
+        appendChild(htmlAst, scriptTag);
     }
-    appendChild(styleTag, new Text(css));
-    appendChild(htmlAst, styleTag);
+
+    if (css.length > 0) {
+        const styleTag = new Element("style", {}, undefined, ElementType.ElementType.Style);
+        for (const child of styleTag.children) {
+            removeElement(child);
+        }
+
+        appendChild(styleTag, new Text(css));
+        appendChild(htmlAst, styleTag);
+    }
 
     const content = serializeHtml(htmlAst);
     return content;

--- a/packages/core/files/utils.ts
+++ b/packages/core/files/utils.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import prettier from "prettier";
+import { executeCli } from "../utils/common.js";
 import type { WorkspaceWithoutExplicitArgs } from "../utils/workspace";
 
 export async function readFile(workspace: WorkspaceWithoutExplicitArgs, filePath: string) {
@@ -49,27 +49,8 @@ export function getFilePath(cwd: string, fileName: string) {
     return path.join(cwd, fileName);
 }
 
-export async function format(workspace: WorkspaceWithoutExplicitArgs, path: string, content: string) {
-    const fullPath = getFilePath(workspace.cwd, path);
-    return await formatFileWithPrettier(fullPath, content);
-}
-
-async function formatFileWithPrettier(path: string, content: string) {
-    const options = await prettier.resolveConfig(path);
-
-    try {
-        return await prettier.format(content, {
-            ...options,
-            filepath: path,
-            plugins: ["prettier-plugin-svelte"],
-        });
-    } catch (error) {
-        // for some untypical file extensions prettier fails because
-        // it's unable to find the appropriate parse. As this has only
-        // to do with formatting and not functionality, we can
-        // just skip formatting in this case.
-        return content;
-    }
+export async function format(workspace: WorkspaceWithoutExplicitArgs, paths: string[]) {
+    await executeCli("npx", ["prettier", "--write", ...paths], workspace.cwd, { stdio: "pipe" });
 }
 
 export const commonFilePaths = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,9 +25,7 @@
     },
     "dependencies": {
         "@svelte-add/ast-manipulation": "workspace:*",
-        "@svelte-add/ast-tooling": "workspace:*",
-        "prettier": "^3.3.2",
-        "prettier-plugin-svelte": "^3.2.4"
+        "@svelte-add/ast-tooling": "workspace:*"
     },
     "bugs": "https://github.com/svelte-add/svelte-add/issues",
     "repository": {

--- a/packages/core/utils/dependencies.ts
+++ b/packages/core/utils/dependencies.ts
@@ -3,7 +3,11 @@ import preferredPackageManager from "preferred-pm";
 import { spinner } from "@svelte-add/clack-prompts";
 import { executeCli } from "./common";
 
-export async function suggestInstallingDependencies(workingDirectory: string) {
+/**
+ * @param workingDirectory
+ * @returns the install status of dependencies
+ */
+export async function suggestInstallingDependencies(workingDirectory: string): Promise<"installed" | "skipped"> {
     type PackageManager = keyof typeof packageManagers | undefined;
     const packageManagers = {
         // Prevents npm from crashing if the peer-deps don't match.
@@ -32,7 +36,7 @@ export async function suggestInstallingDependencies(workingDirectory: string) {
     }
 
     if (!selectedPm || !packageManagers[selectedPm]) {
-        return;
+        return "skipped";
     }
 
     const selectedCommand = packageManagers[selectedPm];
@@ -44,6 +48,7 @@ export async function suggestInstallingDependencies(workingDirectory: string) {
     loadingSpinner.start("Installing dependencies...");
     await installDependencies(command, args, workingDirectory);
     loadingSpinner.stop("Successfully installed dependencies");
+    return "installed";
 }
 
 async function installDependencies(command: string, args: string[], workingDirectory: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,12 +221,6 @@ importers:
       '@svelte-add/ast-tooling':
         specifier: workspace:*
         version: link:../ast-tooling
-      prettier:
-        specifier: ^3.3.2
-        version: 3.3.2
-      prettier-plugin-svelte:
-        specifier: ^3.2.4
-        version: 3.2.4(prettier@3.3.2)(svelte@4.2.18)
     devDependencies:
       '@svelte-add/clack-prompts':
         specifier: workspace:*
@@ -2806,12 +2800,6 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
-
-  prettier-plugin-svelte@3.2.4:
-    resolution: {integrity: sha512-tZv+ADfeOWFNQkXkRh6zUXE16w3Vla8x2Ug0B/EnSmjR4EnwdwZbGgL/liSwR1kcEALU5mAAyua98HBxheCxgg==}
-    peerDependencies:
-      prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -6419,11 +6407,6 @@ snapshots:
   prettier-linter-helpers@1.0.0:
     dependencies:
       fast-diff: 1.3.0
-
-  prettier-plugin-svelte@3.2.4(prettier@3.3.2)(svelte@4.2.18):
-    dependencies:
-      prettier: 3.3.2
-      svelte: 4.2.18
 
   prettier@2.8.8: {}
 


### PR DESCRIPTION
`prettier` is [ginormous](https://npmgraph.js.org/?q=svelte-add#select=exact%3Aprettier%403.3.2&sizing=) and is the largest dependency that users have to download every time they call any of our adders. 

Rather than having it as a direct dependency and using it's api in code, we can check if `prettier` is installed in their project and run the formatter via its CLI after all of the adders have executed and after dependency installations have occurred (covers the case of if `node_modules` isn't installed yet).