### PR TITLE
chore: upgrade all workflow action versions  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout code repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: setup pnpm
               uses: pnpm/action-setup@v4
 
             - name: setup node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   cache: pnpm
@@ -64,13 +64,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout code repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: setup pnpm
               uses: pnpm/action-setup@v4
 
             - name: setup node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   cache: pnpm

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -9,12 +9,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout code repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v4
 
             - name: setup node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   cache: pnpm


### PR DESCRIPTION
At the moment, most of our workflows are [running in Node16](https://github.com/svelte-add/svelte-add/actions/runs/9725826885) (except our changesets workflow) as we're using older versions of actions. This PR upgrades them all so that may run in Node20.