### PR TITLE
chore: fix changesets

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -41,7 +41,6 @@ jobs:
               uses: changesets/action@v1
               with:
                   publish: pnpm ci:publish
-                  version: pnpm ci:version
                   createGithubReleases: false
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "version": "2.0.0",
     "description": "",
     "scripts": {
-        "ci:version": "pnpm utils:readmes && pnpm utils:packages && pnpm changeset version",
         "ci:publish": "changeset publish",
         "prettier:check": "pnpm prettier . --check",
         "prettier:fix": "pnpm prettier . --write",


### PR DESCRIPTION
scripts `pnpm utils:readmes && pnpm utils:packages` no longer exists and is causing the [changesets workflow to fail](https://github.com/svelte-add/svelte-add/actions/runs/9725879570).

`ci:version` is also no longer needed since we don't have to do any additional processing before versioning the packages. the changesets action runs `changesets version` by default, so we can safely remove it.