### PR TITLE
chore: update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
     "typescript.tsserver.experimental.enableProjectDiagnostics": true,
     "cSpell.words": ["ecma", "popperjs", "postcondition", "Postcondition", "postconditions", "Svex", "threlte"],
     "eslint.useFlatConfig": true,
-    "typescript.tsdk": "node_modules\\typescript\\lib"
+    "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "typescript.tsserver.experimental.enableProjectDiagnostics": true,
     "cSpell.words": ["ecma", "popperjs", "postcondition", "Postcondition", "postconditions", "Svex", "threlte"],
-    "eslint.experimental.useFlatConfig": true
+    "eslint.useFlatConfig": true,
+    "typescript.tsdk": "node_modules\\typescript\\lib"
 }


### PR DESCRIPTION
After merging #452, my vscode was still complaining about some type errors, although `pnpm types:check` ran flawlessly. I figured out that my vscode was using the bundled typescript version which is not up to date.

While i was in that config i got a warning that i can remove the experimental key for eslint.