### PR TITLE
fix: alphabetize `dependencies` and `devDependencies`

### DIFF
--- a/.changeset/late-zoos-decide.md
+++ b/.changeset/late-zoos-decide.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: `dependencies` and `devDependencies` are now properly sorted after modification

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -176,6 +176,39 @@ export function parseJson(content: string) {
 export function serializeJson(originalInput: string, data: unknown) {
     // some of the files we need to process contain comments. The default
     // node JSON.parse fails parsing those comments.
-    // return fleece.patch(originalInput, data);
-    return fleece.stringify(data);
+    const spaces = guessIndentString(originalInput);
+    return fleece.stringify(data, { spaces });
+}
+
+// Sourced from `golden-fleece`
+// https://github.com/Rich-Harris/golden-fleece/blob/f2446f331640f325e13609ed99b74b6a45e755c2/src/patch.ts#L302
+function guessIndentString(str: string): number | undefined {
+    const lines = str.split("\n");
+
+    let tabs = 0;
+    let spaces = 0;
+    let minSpaces = 8;
+
+    lines.forEach((line) => {
+        const match = /^(?: +|\t+)/.exec(line);
+        if (!match) return;
+
+        const whitespace = match[0];
+        if (whitespace.length === line.length) return;
+
+        if (whitespace[0] === "\t") {
+            tabs += 1;
+        } else {
+            spaces += 1;
+            if (whitespace.length > 1 && whitespace.length < minSpaces) {
+                minSpaces = whitespace.length;
+            }
+        }
+    });
+
+    if (spaces > tabs) {
+        let result = "";
+        while (minSpaces--) result += " ";
+        return result.length;
+    }
 }

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -173,9 +173,9 @@ export function parseJson(content: string) {
     return fleece.evaluate(content);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function serializeJson(originalInput: string, data: any) {
+export function serializeJson(originalInput: string, data: unknown) {
     // some of the files we need to process contain comments. The default
     // node JSON.parse fails parsing those comments.
-    return fleece.patch(originalInput, data);
+    // return fleece.patch(originalInput, data);
+    return fleece.stringify(data);
 }

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -296,8 +296,20 @@ export async function installPackages<Args extends OptionDefinition>(
         }
     }
 
+    if (data.dependencies) data.dependencies = alphabetizeProperties(data.dependencies);
+    if (data.devDependencies) data.devDependencies = alphabetizeProperties(data.devDependencies);
+
     await writeFile(workspace, commonFilePaths.packageJsonFilePath, serializeJson(originalText, data));
     return commonFilePaths.packageJsonFilePath;
+}
+
+function alphabetizeProperties(obj: Record<string, string>) {
+    const orderedObj: Record<string, string> = {};
+    const sortedEntries = Object.entries(obj).sort(([a], [b]) => a.localeCompare(b));
+    for (const [key, value] of sortedEntries) {
+        orderedObj[key] = value;
+    }
+    return orderedObj;
 }
 
 async function runHooks<Args extends OptionDefinition>(


### PR DESCRIPTION
closes #457

I'm not 100% sure that this is the right solution, but I'll point out my concerns below: