### PR TITLE
fix: preserve formatting for JS files

### DIFF
--- a/.changeset/slow-chairs-tell.md
+++ b/.changeset/slow-chairs-tell.md
@@ -1,0 +1,6 @@
+---
+"@svelte-add/ast-manipulation": patch
+"@svelte-add/ast-tooling": patch
+---
+
+fix: preserve formatting for JS files

--- a/adders/mdsvex/config/adder.ts
+++ b/adders/mdsvex/config/adder.ts
@@ -20,7 +20,7 @@ export const adder = defineAdderConfig({
         {
             name: () => `svelte.config.js`,
             contentType: "script",
-            content: ({ ast, array, object, common, functions, imports, exports }) => {
+            content: ({ ast, array, object, functions, imports, exports }) => {
                 imports.addNamed(ast, "mdsvex", { mdsvex: "mdsvex" });
 
                 const { value: exportDefault } = exports.defaultExport(ast, object.createEmpty());
@@ -41,10 +41,8 @@ export const adder = defineAdderConfig({
 
                 // extensions
                 const extensionsArray = object.property(exportDefault, "extensions", array.createEmpty());
-                const svelteString = common.createLiteral(".svelte");
-                const svxString = common.createLiteral(".svx");
-                array.push(extensionsArray, svelteString);
-                array.push(extensionsArray, svxString);
+                array.push(extensionsArray, ".svelte");
+                array.push(extensionsArray, ".svx");
             },
         },
     ],

--- a/packages/ast-manipulation/js/common.ts
+++ b/packages/ast-manipulation/js/common.ts
@@ -1,4 +1,5 @@
-import { type AstKinds, type AstTypes, Walker, parseScript, serializeScript } from "@svelte-add/ast-tooling";
+import { type AstKinds, type AstTypes, Walker, parseScript, serializeScript, stripAst } from "@svelte-add/ast-tooling";
+import decircular from "decircular";
 
 export function addJsDocTypeComment(node: AstTypes.Node, type: string) {
     const comment: AstTypes.CommentBlock = {
@@ -31,7 +32,13 @@ export function createLiteral(value: string | null = null) {
 }
 
 export function areNodesEqual(ast1: AstTypes.ASTNode, ast2: AstTypes.ASTNode) {
-    return serializeScript(ast1) === serializeScript(ast2);
+    // We're deep cloning these trees so that we can strip the locations off of them for comparisons.
+    // Without this, we'd be getting false negatives due to slight differences in formatting style.
+    // These ASTs are also filled to the brim with circular references, which prevents
+    // us from using `structuredCloned` directly
+    const ast1Clone = decircular(ast1);
+    const ast2Clone = decircular(ast2);
+    return serializeScript(stripAst(ast1Clone, "loc")) === serializeScript(stripAst(ast2Clone, "loc"));
 }
 
 export function blockStatement() {

--- a/packages/ast-manipulation/package.json
+++ b/packages/ast-manipulation/package.json
@@ -13,7 +13,8 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/ast-tooling": "workspace:^"
+        "@svelte-add/ast-tooling": "workspace:^",
+        "decircular": "^1.0.0"
     },
     "bugs": "https://github.com/svelte-add/svelte-add/issues",
     "repository": {

--- a/packages/ast-manipulation/package.json
+++ b/packages/ast-manipulation/package.json
@@ -13,7 +13,9 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/ast-tooling": "workspace:^",
+        "@svelte-add/ast-tooling": "workspace:^"
+    },
+    "devDependencies": {
         "decircular": "^1.0.0"
     },
     "bugs": "https://github.com/svelte-add/svelte-add/issues",

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -52,7 +52,7 @@ export function parseScript(content: string): AstTypes.Program {
         },
     });
 
-    return stripAst(recastOutput.program, "loc");
+    return recastOutput.program;
 }
 
 export function serializeScript(ast: AstTypes.ASTNode) {
@@ -94,8 +94,7 @@ export function stripAst<T>(node: T, propToRemove: string): T {
         }
     }
 
-    // we do this to transform nodes into POJOs
-    return structuredClone(node);
+    return node;
 }
 
 export type SvelteAst = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,7 @@ importers:
       '@svelte-add/ast-tooling':
         specifier: workspace:^
         version: link:../ast-tooling
+    devDependencies:
       decircular:
         specifier: ^1.0.0
         version: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@svelte-add/ast-tooling':
         specifier: workspace:^
         version: link:../ast-tooling
+      decircular:
+        specifier: ^1.0.0
+        version: 1.0.0
 
   packages/ast-tooling:
     devDependencies:
@@ -1261,6 +1264,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decircular@1.0.0:
+    resolution: {integrity: sha512-YhCtYW0jQs9+gzL2vDLxanRhMHeKa55kw5z2oheI6D+MQA7KafrqtiGKhhpKCLZQurm2a9h0LkP9T5z5gy+A0A==}
+    engines: {node: '>=18'}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -4143,6 +4150,8 @@ snapshots:
   debug@4.3.5:
     dependencies:
       ms: 2.1.2
+
+  decircular@1.0.0: {}
 
   decompress-response@6.0.0:
     dependencies:


### PR DESCRIPTION
fixes #464

locations need to be stripped in order for node comparisons to work properly, see: https://github.com/svelte-add/svelte-add/pull/379#discussion_r1638361267

rather than stripping the ast locations from the original tree, we'll now create a clone of the tree and strip it from there during comparisons.

---

notable observation: it doesn't seem to be perfect either, but I'm not sure why. 

for instance, here's the before:
![img](https://i.imgur.com/AH6cEsU.png)

and here's the after:
![img](https://i.imgur.com/mW7yCVh.png)

however, if I format it using tabs and run the adder again, the tabs are entirely preserved... so I'm not quite sure what's going on there 😅 