### PR TITLE
fix: improve robustness of `drizzle` adder

### DIFF
--- a/.changeset/happy-apples-move.md
+++ b/.changeset/happy-apples-move.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/ast-manipulation": patch
+---
+
+chore: `overrideProperty` will now create the property if it's missing

--- a/.changeset/slimy-clocks-cough.md
+++ b/.changeset/slimy-clocks-cough.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/adders": patch
+---
+
+fix: improve robustness of drizzle adder

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -203,12 +203,16 @@ export const adder = defineAdderConfig({
                     }),
                     verbose: { type: "BooleanLiteral", value: true },
                     strict: { type: "BooleanLiteral", value: true },
+                    driver,
                 });
 
                 object.overrideProperties(objExpression, {
                     dialect: common.createLiteral(options.database),
-                    driver: driver,
                 });
+
+                // The `driver` property is only required for _some_ sqlite DBs.
+                // We'll need to remove it if it's anything but sqlite
+                if (options.database !== "sqlite") object.removeProperty(objExpression, "driver");
             },
         },
         {

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -191,25 +191,21 @@ export const adder = defineAdderConfig({
                 const objExpression = exportDefault.arguments?.[0];
                 if (!objExpression || objExpression.type !== "ObjectExpression") return;
 
-                const schemaPath = common.createLiteral(`./src/lib/server/db/schema.${typescript.installed ? "ts" : "js"}`);
-                object.overrideProperty(objExpression, "schema", schemaPath);
-                object.overrideProperty(objExpression, "dialect", common.createLiteral(options.database));
+                const driver = options.sqlite === "turso" ? common.createLiteral("turso") : undefined;
+                const authToken =
+                    options.sqlite === "turso" ? common.expressionFromString("process.env.DATABASE_AUTH_TOKEN") : undefined;
 
-                const dbCredentials = object.createEmpty();
-                object.overrideProperty(dbCredentials, "url", common.expressionFromString("process.env.DATABASE_URL"));
-
-                if (options.sqlite === "turso") {
-                    object.overrideProperty(objExpression, "driver", common.createLiteral("turso"));
-                    object.overrideProperty(
-                        dbCredentials,
-                        "authToken",
-                        common.expressionFromString("process.env.DATABASE_AUTH_TOKEN"),
-                    );
-                }
-
-                object.overrideProperty(objExpression, "dbCredentials", dbCredentials);
-                object.overrideProperty(objExpression, "verbose", { type: "BooleanLiteral", value: true });
-                object.overrideProperty(objExpression, "strict", { type: "BooleanLiteral", value: true });
+                object.overrideProperties(objExpression, {
+                    schema: common.createLiteral(`./src/lib/server/db/schema.${typescript.installed ? "ts" : "js"}`),
+                    dialect: common.createLiteral(options.database),
+                    driver: driver,
+                    dbCredentials: object.create({
+                        url: common.expressionFromString("process.env.DATABASE_URL"),
+                        authToken: authToken,
+                    }),
+                    verbose: { type: "BooleanLiteral", value: true },
+                    strict: { type: "BooleanLiteral", value: true },
+                });
             },
         },
         {

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -224,7 +224,7 @@ export const adder = defineAdderConfig({
                         integer: "integer",
                     });
 
-                    userSchemaExpression = common.expressionFromString(`sqliteTable('user', {
+                    userSchemaExpression = common.expressionFromString(dedent`sqliteTable('user', {
                         id: integer('id').primaryKey(),
                         name: text('name').notNull(),
                         age: integer('age')
@@ -238,7 +238,7 @@ export const adder = defineAdderConfig({
                         int: "int",
                     });
 
-                    userSchemaExpression = common.expressionFromString(`mysqlTable('user', {
+                    userSchemaExpression = common.expressionFromString(dedent`mysqlTable('user', {
                         id: serial("id").primaryKey(),
                         name: text('name').notNull(),
                         age: int('age'),
@@ -252,7 +252,7 @@ export const adder = defineAdderConfig({
                         integer: "integer",
                     });
 
-                    userSchemaExpression = common.expressionFromString(`pgTable('user', {
+                    userSchemaExpression = common.expressionFromString(dedent`pgTable('user', {
                         id: serial('id').primaryKey(),
                         name: text('name').notNull(),
                         age: integer('age'),

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -224,7 +224,7 @@ export const adder = defineAdderConfig({
                         integer: "integer",
                     });
 
-                    userSchemaExpression = common.expressionFromString(dedent`sqliteTable('user', {
+                    userSchemaExpression = common.expressionFromString(`sqliteTable('user', {
                         id: integer('id').primaryKey(),
                         name: text('name').notNull(),
                         age: integer('age')
@@ -238,7 +238,7 @@ export const adder = defineAdderConfig({
                         int: "int",
                     });
 
-                    userSchemaExpression = common.expressionFromString(dedent`mysqlTable('user', {
+                    userSchemaExpression = common.expressionFromString(`mysqlTable('user', {
                         id: serial("id").primaryKey(),
                         name: text('name').notNull(),
                         age: int('age'),
@@ -252,7 +252,7 @@ export const adder = defineAdderConfig({
                         integer: "integer",
                     });
 
-                    userSchemaExpression = common.expressionFromString(dedent`pgTable('user', {
+                    userSchemaExpression = common.expressionFromString(`pgTable('user', {
                         id: serial('id').primaryKey(),
                         name: text('name').notNull(),
                         age: integer('age'),

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -195,16 +195,19 @@ export const adder = defineAdderConfig({
                 const authToken =
                     options.sqlite === "turso" ? common.expressionFromString("process.env.DATABASE_AUTH_TOKEN") : undefined;
 
-                object.overrideProperties(objExpression, {
+                object.properties(objExpression, {
                     schema: common.createLiteral(`./src/lib/server/db/schema.${typescript.installed ? "ts" : "js"}`),
-                    dialect: common.createLiteral(options.database),
-                    driver: driver,
                     dbCredentials: object.create({
                         url: common.expressionFromString("process.env.DATABASE_URL"),
                         authToken: authToken,
                     }),
                     verbose: { type: "BooleanLiteral", value: true },
                     strict: { type: "BooleanLiteral", value: true },
+                });
+
+                object.overrideProperties(objExpression, {
+                    dialect: common.createLiteral(options.database),
+                    driver: driver,
                 });
             },
         },

--- a/adders/drizzle/config/tests.ts
+++ b/adders/drizzle/config/tests.ts
@@ -65,7 +65,7 @@ export const tests = defineAdderTests({
             contentType: "text",
             condition: ({ kit }) => kit.installed,
             content: ({ content }) => {
-                return content.replace("strict: true", "");
+                return content.replace("strict: true,", "");
             },
         },
         {

--- a/packages/ast-manipulation/js/common.ts
+++ b/packages/ast-manipulation/js/common.ts
@@ -1,4 +1,5 @@
 import { type AstKinds, type AstTypes, Walker, parseScript, serializeScript } from "@svelte-add/ast-tooling";
+import dedent from "dedent";
 
 export function addJsDocTypeComment(node: AstTypes.Node, type: string) {
     const comment: AstTypes.CommentBlock = {
@@ -51,7 +52,7 @@ export function expressionStatement(expression: AstKinds.ExpressionKind) {
 }
 
 export function addFromString(ast: AstTypes.BlockStatement | AstTypes.Program, value: string) {
-    const program = parseScript(value);
+    const program = parseScript(dedent(value));
 
     for (const childNode of program.body) {
         ast.body.push(childNode);
@@ -59,7 +60,7 @@ export function addFromString(ast: AstTypes.BlockStatement | AstTypes.Program, v
 }
 
 export function expressionFromString(value: string): AstKinds.ExpressionKind {
-    const program = parseScript(value);
+    const program = parseScript(dedent(value));
     const statement = program.body[0];
     if (statement.type !== "ExpressionStatement") {
         throw new Error("value passed was not an expression");
@@ -69,7 +70,7 @@ export function expressionFromString(value: string): AstKinds.ExpressionKind {
 }
 
 export function statementFromString(value: string): AstKinds.StatementKind {
-    const program = parseScript(value);
+    const program = parseScript(dedent(value));
     const statement = program.body[0];
 
     return statement;

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -39,13 +39,13 @@ export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier
 export function overrideProperty<T extends AstKinds.ExpressionKind>(ast: AstTypes.ObjectExpression, name: string, value: T) {
     const objectExpression = ast;
     const properties = objectExpression.properties.filter((x): x is AstTypes.ObjectProperty => x.type == "ObjectProperty");
-    const property = properties.find((x) => (x.key as AstTypes.Identifier).name == name);
+    const prop = properties.find((x) => (x.key as AstTypes.Identifier).name == name);
 
-    if (!property) {
-        throw new Error(`cannot override non existent property '${name}'`);
+    if (!prop) {
+        return property(ast, name, value);
     }
 
-    property.value = value;
+    prop.value = value;
 
     return value;
 }

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -60,6 +60,16 @@ export function overrideProperties<T extends AstKinds.ExpressionKind>(
     }
 }
 
+export function properties<T extends AstKinds.ExpressionKind>(
+    ast: AstTypes.ObjectExpression,
+    obj: Record<string, T | undefined>,
+) {
+    for (const [prop, value] of Object.entries(obj)) {
+        if (value === undefined) continue;
+        property(ast, prop, value);
+    }
+}
+
 export function create<T extends AstKinds.ExpressionKind>(obj: Record<string, T | undefined>): AstTypes.ObjectExpression {
     const objExpression = createEmpty();
 

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -72,10 +72,10 @@ export function properties<T extends AstKinds.ExpressionKind>(
 
 export function removeProperty(ast: AstTypes.ObjectExpression, property: string) {
     const properties = ast.properties.filter((x): x is AstTypes.ObjectProperty => x.type === "ObjectProperty");
-    const prop = properties.findIndex((x) => (x.key as AstTypes.Identifier).name === property);
+    const propIdx = properties.findIndex((x) => (x.key as AstTypes.Identifier).name === property);
 
-    if (prop !== -1) {
-        ast.properties = ast.properties.splice(prop, 1);
+    if (propIdx !== -1) {
+        ast.properties.splice(propIdx, 1);
     }
 }
 

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -50,6 +50,27 @@ export function overrideProperty<T extends AstKinds.ExpressionKind>(ast: AstType
     return value;
 }
 
+export function overrideProperties<T extends AstKinds.ExpressionKind>(
+    ast: AstTypes.ObjectExpression,
+    obj: Record<string, T | undefined>,
+) {
+    for (const [prop, value] of Object.entries(obj)) {
+        if (value === undefined) continue;
+        overrideProperty(ast, prop, value);
+    }
+}
+
+export function create<T extends AstKinds.ExpressionKind>(obj: Record<string, T | undefined>): AstTypes.ObjectExpression {
+    const objExpression = createEmpty();
+
+    for (const [prop, value] of Object.entries(obj)) {
+        if (value === undefined) continue;
+        property(objExpression, prop, value);
+    }
+
+    return objExpression;
+}
+
 export function createEmpty() {
     const objectExpression: AstTypes.ObjectExpression = {
         type: "ObjectExpression",

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -70,6 +70,15 @@ export function properties<T extends AstKinds.ExpressionKind>(
     }
 }
 
+export function removeProperty(ast: AstTypes.ObjectExpression, property: string) {
+    const properties = ast.properties.filter((x): x is AstTypes.ObjectProperty => x.type === "ObjectProperty");
+    const prop = properties.findIndex((x) => (x.key as AstTypes.Identifier).name === property);
+
+    if (prop !== -1) {
+        ast.properties = ast.properties.splice(prop, 1);
+    }
+}
+
 export function create<T extends AstKinds.ExpressionKind>(obj: Record<string, T | undefined>): AstTypes.ObjectExpression {
     const objExpression = createEmpty();
 

--- a/packages/ast-manipulation/package.json
+++ b/packages/ast-manipulation/package.json
@@ -20,5 +20,8 @@
         "type": "git",
         "url": "https://github.com/svelte-add/svelte-add/tree/main/projects/ast-manipulation"
     },
-    "keywords": []
+    "keywords": [],
+    "devDependencies": {
+        "dedent": "^1.5.3"
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,10 @@ importers:
       '@svelte-add/ast-tooling':
         specifier: workspace:^
         version: link:../ast-tooling
+    devDependencies:
+      dedent:
+        specifier: ^1.5.3
+        version: 1.5.3
 
   packages/ast-tooling:
     devDependencies:


### PR DESCRIPTION
While working on #467, I noticed that the robustness of the drizzle adder's config modifications could be improved. Running the adder again and changing the DB type wouldn't result in updates to the user's `drizzle.config.ts` (i.e. updating the `driver` field from `sqlite` to `mysql`). Now, if the adder is ran again with a different DB selected, the drizzle config will update accordingly.