### PR TITLE
fix: improve svelte config parser

### DIFF
--- a/.changeset/eleven-lamps-attack.md
+++ b/.changeset/eleven-lamps-attack.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: improved parser for `svelte.config.js`

--- a/packages/ast-manipulation/js/exports.ts
+++ b/packages/ast-manipulation/js/exports.ts
@@ -1,4 +1,4 @@
-import { Walker, type AstKinds, type AstTypes } from "@svelte-add/ast-tooling";
+import type { AstKinds, AstTypes } from "@svelte-add/ast-tooling";
 
 export type ExportDefaultReturn<T> = {
     astNode: AstTypes.ExportDefaultDeclaration;
@@ -30,15 +30,14 @@ export function defaultExport<T extends AstKinds.ExpressionKind>(
         let variableDeclarator: AstTypes.VariableDeclarator | undefined;
         for (const declaration of ast.body) {
             if (declaration.type !== "VariableDeclaration") continue;
-            // prettier-ignore
-            Walker.walk(declaration as AstTypes.ASTNode, {}, {
-                VariableDeclarator(node) {
-                    if (node.id.type === "Identifier" && node.id.name === identifier.name) {
-                        variableDeclarator = node;
-                        variableDeclaration = declaration;
-                    }
-                }
-            })
+
+            const declarator = declaration.declarations.find(
+                (d): d is AstTypes.VariableDeclarator =>
+                    d.type === "VariableDeclarator" && d.id.type === "Identifier" && d.id.name === identifier.name,
+            );
+
+            variableDeclarator = declarator;
+            variableDeclaration = declaration;
         }
         if (!variableDeclaration || !variableDeclarator) throw new Error(`Unable to find exported variable '${identifier.name}'`);
 

--- a/packages/ast-manipulation/js/object.ts
+++ b/packages/ast-manipulation/js/object.ts
@@ -57,8 +57,3 @@ export function createEmpty() {
     };
     return objectExpression;
 }
-
-export type ExportDefaultReturn<T> = {
-    astNode: AstTypes.ExportDefaultDeclaration;
-    value: T;
-};

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -27,7 +27,7 @@ import { validatePreconditions } from "./preconditions.js";
 import { endPrompts, startPrompts } from "../utils/prompts.js";
 import { checkPostconditions, printUnmetPostconditions } from "./postconditions.js";
 import { displayNextSteps } from "./nextSteps.js";
-import { spinner, log } from "@svelte-add/clack-prompts";
+import { spinner, log, cancel } from "@svelte-add/clack-prompts";
 import { executeCli } from "../utils/cli.js";
 
 export type AdderDetails<Args extends OptionDefinition> = {
@@ -68,34 +68,41 @@ export async function executeAdders<Args extends OptionDefinition>(
     remoteControlOptions: RemoteControlOptions | undefined = undefined,
     selectAddersToApply: AddersToApplySelector | undefined = undefined,
 ) {
-    const adderDetailsByAdderId: Map<string, AdderDetails<Args>> = new Map();
-    adderDetails.map((x) => adderDetailsByAdderId.set(x.config.metadata.id, x));
+    try {
+        const adderDetailsByAdderId: Map<string, AdderDetails<Args>> = new Map();
+        adderDetails.map((x) => adderDetailsByAdderId.set(x.config.metadata.id, x));
 
-    const remoteControlled = remoteControlOptions !== undefined;
-    const isTesting = remoteControlled && remoteControlOptions.isTesting;
+        const remoteControlled = remoteControlOptions !== undefined;
+        const isTesting = remoteControlled && remoteControlOptions.isTesting;
 
-    const cliOptions = !isTesting ? prepareAndParseCliOptions(adderDetails) : {};
-    const commonCliOptions = extractCommonCliOptions(cliOptions);
-    const cliOptionsByAdderId =
-        (!isTesting ? extractAdderCliOptions(cliOptions, adderDetails) : remoteControlOptions.adderOptions) ?? {};
-    validateOptionTypes(adderDetails, cliOptionsByAdderId);
+        const cliOptions = !isTesting ? prepareAndParseCliOptions(adderDetails) : {};
+        const commonCliOptions = extractCommonCliOptions(cliOptions);
+        const cliOptionsByAdderId =
+            (!isTesting ? extractAdderCliOptions(cliOptions, adderDetails) : remoteControlOptions.adderOptions) ?? {};
+        validateOptionTypes(adderDetails, cliOptionsByAdderId);
 
-    let workingDirectory: string | null;
-    if (isTesting) workingDirectory = remoteControlOptions.workingDirectory;
-    else workingDirectory = determineWorkingDirectory(commonCliOptions.path);
-    workingDirectory = await detectSvelteDirectory(workingDirectory);
-    const createProject = workingDirectory == null;
-    if (!workingDirectory) workingDirectory = process.cwd();
+        let workingDirectory: string | null;
+        if (isTesting) workingDirectory = remoteControlOptions.workingDirectory;
+        else workingDirectory = determineWorkingDirectory(commonCliOptions.path);
+        workingDirectory = await detectSvelteDirectory(workingDirectory);
+        const createProject = workingDirectory == null;
+        if (!workingDirectory) workingDirectory = process.cwd();
 
-    const executionPlan: AddersExecutionPlan = {
-        workingDirectory,
-        createProject,
-        commonCliOptions,
-        cliOptionsByAdderId,
-        selectAddersToApply,
-    };
+        const executionPlan: AddersExecutionPlan = {
+            workingDirectory,
+            createProject,
+            commonCliOptions,
+            cliOptionsByAdderId,
+            selectAddersToApply,
+        };
 
-    await executePlan(executionPlan, executingAdder, adderDetails, remoteControlOptions);
+        await executePlan(executionPlan, executingAdder, adderDetails, remoteControlOptions);
+    } catch (e) {
+        if (e instanceof Error) cancel(e.message);
+        else cancel("Something went wrong.");
+        console.error(e);
+        process.exit(1);
+    }
 }
 
 async function executePlan<Args extends OptionDefinition>(

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -94,10 +94,8 @@ export async function parseSvelteConfigIntoWorkspace(workspace: WorkspaceWithout
         const configIdentifier = defaultExport.declaration.name;
         for (const statement of ast.body) {
             if (statement.type !== "VariableDeclaration") continue;
-            Walker.walk(
-                statement as AstTypes.ASTNode,
-                {},
-                {
+            // prettier-ignore
+            Walker.walk(statement as AstTypes.ASTNode, {}, {
                     VariableDeclarator(node, ctx) {
                         if (objectExpression) ctx.stop();
                         if (node.id.type === "Identifier" && node.id.name === configIdentifier) {

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -96,8 +96,7 @@ export async function parseSvelteConfigIntoWorkspace(workspace: WorkspaceWithout
             if (statement.type !== "VariableDeclaration") continue;
             // prettier-ignore
             Walker.walk(statement as AstTypes.ASTNode, {}, {
-                    VariableDeclarator(node, ctx) {
-                        if (objectExpression) ctx.stop();
+                    VariableDeclarator(node) {
                         if (node.id.type === "Identifier" && node.id.name === configIdentifier) {
                             if (node.init?.type !== "ObjectExpression")
                                 throw Error("Unable to find svelte config object expression from `svelte.config.js`");

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -82,11 +82,8 @@ export async function parseSvelteConfigIntoWorkspace(workspace: WorkspaceWithout
     const ast = parseScript(configText);
     const editor = getJsAstEditor(ast);
 
-    let defaultExport = ast.body.find((s) => s.type === "ExportDefaultDeclaration");
-    if (!defaultExport) {
-        defaultExport = { type: "ExportDefaultDeclaration", declaration: editor.object.createEmpty() };
-        ast.body.push(defaultExport);
-    }
+    const defaultExport = ast.body.find((s) => s.type === "ExportDefaultDeclaration");
+    if (!defaultExport) throw Error("Missing default export in `svelte.config.js`");
 
     let objectExpression: AstTypes.ObjectExpression | undefined;
     if (defaultExport.declaration.type === "Identifier") {

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -100,7 +100,7 @@ export async function parseSvelteConfigIntoWorkspace(workspace: WorkspaceWithout
                         if (objectExpression) ctx.stop();
                         if (node.id.type === "Identifier" && node.id.name === configIdentifier) {
                             if (node.init?.type !== "ObjectExpression")
-                                throw Error("Unable to find svelte config object from `svelte.config.js`");
+                                throw Error("Unable to find svelte config object expression from `svelte.config.js`");
                             objectExpression = node.init;
                         }
                     },

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -97,11 +97,12 @@ export async function parseSvelteConfigIntoWorkspace(workspace: WorkspaceWithout
                     d.type === "VariableDeclarator" && d.id.type === "Identifier" && d.id.name === identifier.name,
             );
 
-            if (declarator?.init?.type !== "ObjectExpression")
-                throw Error("Unable to find svelte config object expression from `svelte.config.js`");
+            if (declarator?.init?.type !== "ObjectExpression") continue;
 
             objectExpression = declarator.init;
         }
+
+        if (!objectExpression) throw Error("Unable to find svelte config object expression from `svelte.config.js`");
     } else if (defaultExport.declaration.type === "ObjectExpression") {
         // e.g. `export default { ... };`
         objectExpression = defaultExport.declaration;


### PR DESCRIPTION
fixes #473 

The CLI will fail to startup if the variable for the svelte config object isn't the first declared variable.

for example, this is OK:
```js
import adapter from "@sveltejs/adapter-auto";
import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";

/** @type {import('@sveltejs/kit').Config} */
const config = {
    // Consult https://kit.svelte.dev/docs/integrations#preprocessors
    // for more information about preprocessors
    preprocess: [vitePreprocess()],

    kit: {
        // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
        // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
        // See https://kit.svelte.dev/docs/adapters for more information about adapters.
        adapter: adapter()
    },
};

export default config;
```

but declaring any other variable before the `config` will cause the parser to error:
```diff
import adapter from "@sveltejs/adapter-auto";
import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";

+ const x = "foo";

/** @type {import('@sveltejs/kit').Config} */
const config = {
    // Consult https://kit.svelte.dev/docs/integrations#preprocessors
    // for more information about preprocessors
    preprocess: [vitePreprocess()],

    kit: {
        // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
        // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
        // See https://kit.svelte.dev/docs/adapters for more information about adapters.
        adapter: adapter()
    },
};

export default config;
```

This PR improves the parser and allows it to correctly detect the config object no matter the name, declaration order, or if it's exported directly with an object expression (`export default {...}`). I also wrapped the main execution block in a `try catch` so that thrown errors are logged a bit better.