### PR TITLE
fix: better file error handling

### DIFF
--- a/.changeset/thirty-countries-kiss.md
+++ b/.changeset/thirty-countries-kiss.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: better file error handling


### PR DESCRIPTION
Identified based on the issue detailed in #477. The main point is to include the file name for better debugging. This may also allow the user to make his own adjustments before opening an issue

Before this change: 
```
└  Identifier 'text' has already been declared. (2:22)

SyntaxError: Identifier 'text' has already been declared. (2:22)
    at constructor (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:9480:20)
    at V8IntrinsicMixin.raise (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:12362:20)
    at TypeScriptScopeHandler.declareName (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:16012:22)
    at V8IntrinsicMixin.declareNameFromIdentifier (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:16438:17)
    at V8IntrinsicMixin.checkIdentifier (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:16434:13)
    at V8IntrinsicMixin.checkLVal (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:16380:13)
    at V8IntrinsicMixin.finishImportSpecifier (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:22845:11)
    at V8IntrinsicMixin.parseImportSpecifier (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:23009:18)
    at V8IntrinsicMixin.parseImportSpecifier (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:18859:19)
    at V8IntrinsicMixin.parseNamedImportSpecifiers (file:///D:/dev/web/svelte-add/packages/ast-tooling/build/index.js:22988:37) {
  code: 'BABEL_PARSER_SYNTAX_ERROR',
  reasonCode: 'VarRedeclaration',
  loc: Position { line: 2, column: 22, index: 95 },
  pos: 95
}
```

After this change:
```
Unable to process 'src/lib/server/db/schema.ts'. Reason: Identifier 'text' has already been declared. (2:22)

Error: Unable to process 'src/lib/server/db/schema.ts'. Reason: Identifier 'text' has already been declared. (2:22)
    at createOrUpdateFiles (file:///D:/dev/web/svelte-add/packages/core/build/internal.js:2018:37)
    at async processInlineAdder (file:///D:/dev/web/svelte-add/packages/core/build/internal.js:16030:33)
    at async executePlan (file:///D:/dev/web/svelte-add/packages/core/build/internal.js:15994:28)
    at async executeAdders (file:///D:/dev/web/svelte-add/packages/core/build/internal.js:15918:5)
    at async executeCli (file:///D:/dev/web/svelte-add/packages/cli/build/index.js:63:3)
```