### PR TITLE
fix: correct typo in package manager prompt

### DIFF
--- a/.changeset/silent-turkeys-sell.md
+++ b/.changeset/silent-turkeys-sell.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: correct typo in package manager prompt

--- a/packages/core/utils/dependencies.ts
+++ b/packages/core/utils/dependencies.ts
@@ -22,7 +22,7 @@ export async function suggestInstallingDependencies(workingDirectory: string): P
     const detectedPm = await preferredPackageManager(workingDirectory);
     let selectedPm: PackageManager;
     if (!detectedPm) {
-        selectedPm = await selectPrompt("Which package manager to want to install dependencies with?", undefined, [
+        selectedPm = await selectPrompt("Which package manager do you want to install dependencies with?", undefined, [
             {
                 label: "None",
                 value: undefined,


### PR DESCRIPTION
closes https://github.com/svelte-add/svelte-add/issues/479