### PR TITLE
docs: add correct adder script

### DIFF
--- a/.changeset/cyan-kings-call.md
+++ b/.changeset/cyan-kings-call.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/website": patch
+---
+
+use correct command if only selecting one adder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,14 @@ pnpm test bulma mdsvex
 ```
 
 And if you have made changes to the core packages, you should probably run the full test suite for all adders. But keep in mind, this takes time!
+
+## website
+
+Our website depends on our internal packages present in the repo. Please run the following commands to start developing on the website.
+
+```sh
+pnpm build:prod # builds all adders and their dependant projects
+pnpm website:dev # starts the website.
+```
+
+Please don't forget to add a changeset, see [changesets](#changesets)

--- a/packages/website/src/lib/Configurator.svelte
+++ b/packages/website/src/lib/Configurator.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { browser } from "$app/environment";
-    import Box from "./Box.svelte";
-    import CopyCommand from "./CopyCommand.svelte";
     import type { AvailableCliOptions } from "@svelte-add/core/internal";
     import type { AdderMetadataWithOptions } from "./adder.js";
+    import Box from "./Box.svelte";
+    import CopyCommand from "./CopyCommand.svelte";
 
     export let adders: AdderMetadataWithOptions[] = [];
 
@@ -46,7 +46,7 @@
             const adderIds = Object.keys(args).join(" ");
             command += `svelte-add@latest ${adderIds}`;
         } else {
-            command += "@svelte-add/" + firstAdderId + "@latest";
+            command += "svelte-add " + firstAdderId + "@latest";
         }
 
         for (const [adderId, options] of argumentEntries) {

--- a/packages/website/src/lib/Configurator.svelte
+++ b/packages/website/src/lib/Configurator.svelte
@@ -46,7 +46,7 @@
             const adderIds = Object.keys(args).join(" ");
             command += `svelte-add@latest ${adderIds}`;
         } else {
-            command += "svelte-add " + firstAdderId + "@latest";
+            command += "svelte-add@latest " + firstAdderId;
         }
 
         for (const [adderId, options] of argumentEntries) {


### PR DESCRIPTION
Follow-up on #489 

Right now, when I click an adder option from the docs (`+`), it configures the old syntax of `@svelte-add/{something}`

I didn't test locally, unfortunately, because the local dev server threw an error:

```
[plugin:vite:import-analysis] Failed to resolve entry for package "@svelte-add/config". The package may have incorrect main/module/exports specified in its package.json.
``` 

So please feel free to close if this is wrong.