### PR TITLE
fix: Replace `@tailwind` directives for `@import`

### DIFF
--- a/.changeset/funny-glasses-pump.md
+++ b/.changeset/funny-glasses-pump.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/adders": patch
+---
+
+fix: Replaced `@tailwind` directives for `@import`

--- a/.changeset/funny-glasses-pump.md
+++ b/.changeset/funny-glasses-pump.md
@@ -2,4 +2,4 @@
 "@svelte-add/adders": patch
 ---
 
-fix: Replaced `@tailwind` directives for `@import`
+fix: replaced `@tailwind` directives for `@import`

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -74,7 +74,7 @@ export const adder = defineAdderConfig({
             content: ({ ast, addAtRule }) => {
                 const atRules = ['"tailwindcss/utilities"', '"tailwindcss/components"', '"tailwindcss/base"'];
                 for (const name of atRules) {
-                    addAtRule(ast, "tailwind", name);
+                    addAtRule(ast, "import", name);
                 }
             },
         },

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -72,7 +72,7 @@ export const adder = defineAdderConfig({
             name: () => "src/app.css",
             contentType: "css",
             content: ({ ast, addAtRule }) => {
-                const atRules = ["utilities", "components", "base"];
+                const atRules = ['"tailwindcss/utilities"', '"tailwindcss/components"', '"tailwindcss/base"'];
                 for (const name of atRules) {
                     addAtRule(ast, "tailwind", name);
                 }


### PR DESCRIPTION
Addresses one of the issues from #482

Replaces the tailwind directives:
```css
@tailwind base;
@tailwind components;
@tailwind utilities;
```
for imports:
```css
@import "tailwindcss/base";
@import "tailwindcss/components";
@import "tailwindcss/utilities";
```

This was done for better compatibility when the adder is used in preexisting projects that have `@import` rules already applied. See https://github.com/svelte-add/svelte-add/issues/482#issuecomment-2239733898 for more details.