### PR TITLE
chore: workspace deps should specify exact versions on publish

### DIFF
--- a/.changeset/breezy-knives-crash.md
+++ b/.changeset/breezy-knives-crash.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/ast-tooling": patch
+---
+
+chore: use `stringify` instead of `patch`

--- a/.changeset/two-avocados-brush.md
+++ b/.changeset/two-avocados-brush.md
@@ -1,5 +1,6 @@
 ---
 "@svelte-add/ast-manipulation": patch
+"@svelte-add/testing-library": patch
 "@svelte-add/website": patch
 "@svelte-add/core": patch
 "svelte-add": patch

--- a/.changeset/two-avocados-brush.md
+++ b/.changeset/two-avocados-brush.md
@@ -1,0 +1,9 @@
+---
+"@svelte-add/ast-manipulation": patch
+"@svelte-add/testing-library": patch
+"@svelte-add/website": patch
+"@svelte-add/core": patch
+"svelte-add": patch
+---
+
+fix: pin workspace dependencies versions

--- a/.changeset/two-avocados-brush.md
+++ b/.changeset/two-avocados-brush.md
@@ -1,6 +1,5 @@
 ---
 "@svelte-add/ast-manipulation": patch
-"@svelte-add/testing-library": patch
 "@svelte-add/website": patch
 "@svelte-add/core": patch
 "svelte-add": patch

--- a/packages/ast-manipulation/package.json
+++ b/packages/ast-manipulation/package.json
@@ -13,7 +13,7 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/ast-tooling": "workspace:^"
+        "@svelte-add/ast-tooling": "workspace:*"
     },
     "bugs": "https://github.com/svelte-add/svelte-add/issues",
     "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,11 +7,11 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/config": "workspace:^",
-        "@svelte-add/core": "workspace:^"
+        "@svelte-add/config": "workspace:*",
+        "@svelte-add/core": "workspace:*"
     },
     "devDependencies": {
-        "@svelte-add/adders": "workspace:^",
+        "@svelte-add/adders": "workspace:*",
         "commander": "^12.1.0"
     }
 }

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "bin": "./index.js",
     "devDependencies": {
-        "@svelte-add/ast-manipulation": "workspace:^",
-        "@svelte-add/ast-tooling": "workspace:^",
-        "@svelte-add/core": "workspace:^"
+        "@svelte-add/ast-manipulation": "workspace:*",
+        "@svelte-add/ast-tooling": "workspace:*",
+        "@svelte-add/core": "workspace:*"
     },
     "dependencies": {
         "npm-check-updates": "^16.14.20"

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -13,7 +13,7 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/core": "workspace:*",
+        "@svelte-add/core": "workspace:^",
         "playwright": "^1.44.1",
         "create-svelte": "^6.3.0"
     },

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -13,7 +13,6 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/core": "workspace:^",
         "playwright": "^1.44.1",
         "create-svelte": "^6.3.0"
     },
@@ -21,6 +20,9 @@
         "promise-parallel-throttle": "^3.5.0",
         "terminate": "^2.6.1",
         "uid": "^2.0.2"
+    },
+    "peerDependencies": {
+        "@svelte-add/core": "workspace:^"
     },
     "bugs": "https://github.com/svelte-add/svelte-add/issues",
     "repository": {

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -13,7 +13,7 @@
         "build"
     ],
     "dependencies": {
-        "@svelte-add/core": "workspace:^",
+        "@svelte-add/core": "workspace:*",
         "playwright": "^1.44.1",
         "create-svelte": "^6.3.0"
     },

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "bin": "./build/index.js",
     "devDependencies": {
-        "@svelte-add/testing-library": "workspace:^",
-        "@svelte-add/adders": "workspace:^",
-        "@svelte-add/core": "workspace:^",
-        "@svelte-add/config": "workspace:^"
+        "@svelte-add/testing-library": "workspace:*",
+        "@svelte-add/adders": "workspace:*",
+        "@svelte-add/core": "workspace:*",
+        "@svelte-add/config": "workspace:*"
     }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -24,8 +24,8 @@
         "vite": "^5.3.0"
     },
     "dependencies": {
-        "@svelte-add/adders": "workspace:^",
-        "@svelte-add/config": "workspace:^",
-        "@svelte-add/core": "workspace:^"
+        "@svelte-add/adders": "workspace:*",
+        "@svelte-add/config": "workspace:*",
+        "@svelte-add/core": "workspace:*"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
   packages/ast-manipulation:
     dependencies:
       '@svelte-add/ast-tooling':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../ast-tooling
     devDependencies:
       dedent:
@@ -148,14 +148,14 @@ importers:
   packages/cli:
     dependencies:
       '@svelte-add/config':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../config
       '@svelte-add/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
     devDependencies:
       '@svelte-add/adders':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../adders
       commander:
         specifier: ^12.1.0
@@ -195,19 +195,19 @@ importers:
         version: 16.14.20
     devDependencies:
       '@svelte-add/ast-manipulation':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../ast-manipulation
       '@svelte-add/ast-tooling':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../ast-tooling
       '@svelte-add/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
 
   packages/testing-library:
     dependencies:
       '@svelte-add/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
       create-svelte:
         specifier: ^6.3.0
@@ -229,28 +229,28 @@ importers:
   packages/tests:
     devDependencies:
       '@svelte-add/adders':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../adders
       '@svelte-add/config':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../config
       '@svelte-add/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
       '@svelte-add/testing-library':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../testing-library
 
   packages/website:
     dependencies:
       '@svelte-add/adders':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../adders
       '@svelte-add/config':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../config
       '@svelte-add/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
     devDependencies:
       '@sveltejs/adapter-static':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,7 @@ importers:
   packages/testing-library:
     dependencies:
       '@svelte-add/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       create-svelte:
         specifier: ^6.3.0


### PR DESCRIPTION
At the moment, trying to run older versions of `svelte-add` is kind of broken.

For instance, running:
```bash
pnpx svelte-add@2.3.0
```
will break due to `prettier` being added to the config when it doesn't exist locally in this package yet (it was added in `2.3.7`). I suspect this is partially the reason why #457 is broken in some cases. 

This is happening because range specifiers are being using when our workspace packages are referencing each other with `workspace:^`. Instead, we should be using `workspace:*` to specify exact versions on publish (this would effectively be equivalent to us bundling everything into a single package, but due to build times with AST tooling, it's not viable).

When publishing with `workspace:^`, workspace deps will have their versions set to `^2.3.5`. With `workspace:*`, the version will be set to `2.3.5` instead.

Also adding a changeset for `ast-tooling` to fix #457
