### PR TITLE
fix(tailwind): Only insert `prettier-plugin-tailwindcss` to `.prettierrc` if it doesn't exist

### DIFF
--- a/.changeset/sweet-bees-happen.md
+++ b/.changeset/sweet-bees-happen.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/adders": patch
+---
+
+fix: only add `prettier-plugin-tailwindcss` if it doesn't already exists

--- a/.changeset/sweet-bees-happen.md
+++ b/.changeset/sweet-bees-happen.md
@@ -2,4 +2,4 @@
 "@svelte-add/adders": patch
 ---
 
-fix: only add `prettier-plugin-tailwindcss` if it doesn't already exists
+fix: only add `prettier-plugin-tailwindcss` if it doesn't exist

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -102,9 +102,12 @@ export const adder = defineAdderConfig({
             name: () => ".prettierrc",
             contentType: "json",
             content: ({ data }) => {
-                if (!data.plugins) data.plugins = [];
+                const PLUGIN_NAME = "prettier-plugin-tailwindcss";
 
-                data.plugins.push("prettier-plugin-tailwindcss");
+                data.plugins ??= [];
+                const plugins: string[] = data.plugins;
+
+                if (!plugins.includes(PLUGIN_NAME)) plugins.push(PLUGIN_NAME);
             },
             condition: ({ prettier }) => prettier.installed,
         },


### PR DESCRIPTION
Noticed when running the tailwind adder, `prettier-plugin-tailwindcss` would continously be appended to the plugin array in `.prettierrc`, even when it already exists. This PR fixes that.