### PR TITLE
fix(tailwind): ensure `@import` rules are single spaced when added

### DIFF
--- a/.changeset/ninety-squids-grow.md
+++ b/.changeset/ninety-squids-grow.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/adders": patch
+---
+
+fix: ensure `@import` rules are single spaced

--- a/.changeset/old-hornets-design.md
+++ b/.changeset/old-hornets-design.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/ast-manipulation": minor
+---
+
+feat: added `addImports` method for CSS editor

--- a/.changeset/soft-cars-end.md
+++ b/.changeset/soft-cars-end.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/ast-tooling": patch
+---
+
+chore: expose `CssChildNode`

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -72,10 +72,18 @@ export const adder = defineAdderConfig({
             name: () => "src/app.css",
             contentType: "css",
             content: ({ ast, addAtRule }) => {
-                const atRules = ["utilities", "components", "base"];
-                for (const name of atRules) {
-                    addAtRule(ast, "tailwind", name);
+                const atRules = ['"tailwindcss/utilities"', '"tailwindcss/components"', '"tailwindcss/base"'];
+                const firstNode = ast.first;
+                const nodes = atRules.map((name) => addAtRule(ast, "import", name));
+
+                if (firstNode !== nodes.at(-1) && firstNode?.type === "atrule" && firstNode.name === "import") {
+                    firstNode.raws.before = "\n";
                 }
+
+                nodes.forEach((n, i) => {
+                    // prevents a new line being added at the top of the stylesheet
+                    if (i !== nodes.length - 1) n.raws.before = "\n";
+                });
             },
         },
         {

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -76,7 +76,7 @@ export const adder = defineAdderConfig({
                 const firstNode = ast.first;
                 const nodes = atRules.map((name) => addAtRule(ast, "import", name));
 
-                if (firstNode !== nodes.at(-1) && firstNode?.type === "atrule" && firstNode.name === "import") {
+                if (firstNode !== ast.first && firstNode?.type === "atrule" && firstNode.name === "import") {
                     firstNode.raws.before = "\n";
                 }
 

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -71,23 +71,11 @@ export const adder = defineAdderConfig({
         {
             name: () => "src/app.css",
             contentType: "css",
-            content: ({ ast, AtRule }) => {
-                const layers = ["base", "components", "utilities"];
+            content: ({ ast, addImports }) => {
+                const layerImports = ["base", "components", "utilities"].map((layer) => `"tailwindcss/${layer}"`);
                 const originalFirst = ast.first;
 
-                let prev: typeof originalFirst;
-                const nodes = layers.map((layer) => {
-                    const param = `"tailwindcss/${layer}"`;
-                    const found = ast.nodes.find((x) => x.type === "atrule" && x.name === "import" && x.params === param);
-
-                    if (found) return (prev = found);
-
-                    const rule = new AtRule({ name: "import", params: param });
-                    if (prev) ast.insertAfter(prev, rule);
-                    else ast.prepend(rule);
-
-                    return (prev = rule);
-                });
+                const nodes = addImports(ast, layerImports);
 
                 if (originalFirst !== ast.first && originalFirst?.type === "atrule" && originalFirst.name === "import") {
                     originalFirst.raws.before = "\n";

--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -72,9 +72,9 @@ export const adder = defineAdderConfig({
             name: () => "src/app.css",
             contentType: "css",
             content: ({ ast, addAtRule }) => {
-                const atRules = ['"tailwindcss/utilities"', '"tailwindcss/components"', '"tailwindcss/base"'];
+                const imports = ['"tailwindcss/utilities"', '"tailwindcss/components"', '"tailwindcss/base"'];
                 const firstNode = ast.first;
-                const nodes = atRules.map((name) => addAtRule(ast, "import", name));
+                const nodes = imports.map((name) => addAtRule(ast, "import", name));
 
                 if (firstNode !== ast.first && firstNode?.type === "atrule" && firstNode.name === "import") {
                     firstNode.raws.before = "\n";

--- a/packages/ast-manipulation/css/index.ts
+++ b/packages/ast-manipulation/css/index.ts
@@ -6,6 +6,10 @@ export type CssAstEditor = {
     addDeclaration: typeof addDeclaration;
     addAtRule: typeof addAtRule;
     addComment: typeof addComment;
+    Declaration: typeof Declaration;
+    AtRule: typeof AtRule;
+    Rule: typeof Rule;
+    Comment: typeof Comment;
 };
 
 export function getCssAstEditor(ast: CssAst) {
@@ -15,6 +19,10 @@ export function getCssAstEditor(ast: CssAst) {
         addAtRule,
         addDeclaration,
         addComment,
+        Declaration,
+        AtRule,
+        Rule,
+        Comment,
     };
 
     return editor;

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -4,7 +4,7 @@ import { Document, Element, Text, type ChildNode } from "domhandler";
 import { ElementType, parseDocument } from "htmlparser2";
 import { appendChild, prependChild, removeElement, textContent } from "domutils";
 import serializeDom from "dom-serializer";
-import { Root as CssAst, Declaration, Rule, AtRule, Comment } from "postcss";
+import { Root as CssAst, Declaration, Rule, AtRule, Comment, type ChildNode as CssChildNode } from "postcss";
 import { parse as postcssParse } from "postcss";
 import * as fleece from "silver-fleece";
 import * as Walker from "zimmerframe";
@@ -43,6 +43,9 @@ export type {
     // js
     AstTypes,
     AstKinds,
+
+    //css
+    CssChildNode,
 };
 
 export function parseScript(content: string): AstTypes.Program {


### PR DESCRIPTION
Note: this PR should be merged after #492 

Fixes #482

`@import` rules will now be added with the correct spacing:
```css
@import "tailwindcss/base";
@import "tailwindcss/components";
@import "tailwindcss/utilities";
@import "@fontsource/fira-mono";

:root {
...
```