### PR TITLE
docs: update changelog item description

### DIFF
--- a/.changeset/rich-clouds-smash.md
+++ b/.changeset/rich-clouds-smash.md
@@ -3,4 +3,4 @@
 "@svelte-add/core": patch
 ---
 
-chore: Revert storybook adder back to @latest when v8.2.0 releases
+chore: install packages without `--legacy-peer-deps` flag when using npm


### PR DESCRIPTION
https://github.com/svelte-add/svelte-add/pull/393 still uses the `@next` tag