### PR TITLE
chore: trigger releases

### DIFF
--- a/.changeset/thirty-tools-compete.md
+++ b/.changeset/thirty-tools-compete.md
@@ -1,0 +1,10 @@
+---
+"@svelte-add/ast-manipulation": patch
+"@svelte-add/ast-tooling": patch
+"svelte-add": patch
+"@svelte-add/config": patch
+"@svelte-add/core": patch
+"@svelte-add/testing-library": patch
+---
+
+chore: trigger release


### PR DESCRIPTION
fixes #503 

Because #498 didn't publish properly, the release had to be manually published (although I'm unsure which of those packages were actually published). 

This PR adds a changeset to all public packages to ensure their latest code changes are published.