### PR TITLE
fix: typescript detection

### DIFF
--- a/.changeset/angry-ducks-grin.md
+++ b/.changeset/angry-ducks-grin.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/testing-library": patch
+---
+
+chore: bump `create-svelte`

--- a/.changeset/neat-ravens-peel.md
+++ b/.changeset/neat-ravens-peel.md
@@ -1,0 +1,5 @@
+---
+"@svelte-add/core": patch
+---
+
+fix: typescript detection

--- a/packages/core/files/utils.ts
+++ b/packages/core/files/utils.ts
@@ -66,3 +66,29 @@ export const commonFilePaths = {
 	packageJsonFilePath: 'package.json',
 	svelteConfigFilePath: 'svelte.config.js',
 };
+
+export async function findUp(searchPath: string, fileName: string, maxDepth?: number) {
+	// partially sourced from https://github.com/privatenumber/get-tsconfig/blob/9e78ec52d450d58743439358dd88e2066109743f/src/utils/find-up.ts#L5
+	let depth = 0;
+	while (!maxDepth || depth < maxDepth) {
+		const configPath = path.posix.join(searchPath, fileName);
+
+		try {
+			// `access` throws an exception if the file could not be found
+			await fs.access(configPath);
+			return true;
+		} catch {
+			const parentPath = path.dirname(searchPath);
+			if (parentPath === searchPath) {
+				// root directory
+				return false;
+			}
+
+			searchPath = parentPath;
+		}
+
+		depth++;
+	}
+
+	return false;
+}

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -89,7 +89,7 @@ export async function populateWorkspaceDetails(
 		} else {
 			usesTypescript ||= await findUp(workingDirectory, tsConfigFileName);
 		}
-		
+
 		workspace.typescript.installed = usesTypescript;
 		workspace.prettier.installed = 'prettier' in packageJson.devDependencies;
 		workspace.kit.installed = '@sveltejs/kit' in packageJson.devDependencies;

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -80,20 +80,17 @@ export async function populateWorkspaceDetails(
 	if (packageJson.devDependencies) {
 		const tsConfigFileName = 'tsconfig.json';
 		const viteConfigFileName = 'vite.config.ts';
-		let tsConfigExists,
-			viteConfigExists = false;
+		let usesTypescript = await fileExists(path.join(workingDirectory, viteConfigFileName));
 
 		if (remoteControl.isRemoteControlled()) {
 			// while executing tests, we only look into the direct `workingDirectory`
 			// as we might detect the monorepo `tsconfig.json` otherwise.
-			tsConfigExists = await fileExists(path.join(workingDirectory, tsConfigFileName));
-			viteConfigExists = await fileExists(path.join(workingDirectory, viteConfigFileName));
+			usesTypescript ||= await fileExists(path.join(workingDirectory, tsConfigFileName));
 		} else {
-			tsConfigExists = await findUp(workingDirectory, tsConfigFileName);
-			viteConfigExists = await findUp(workingDirectory, viteConfigFileName);
+			usesTypescript ||= await findUp(workingDirectory, tsConfigFileName);
 		}
-
-		workspace.typescript.installed = tsConfigExists || viteConfigExists;
+		
+		workspace.typescript.installed = usesTypescript;
 		workspace.prettier.installed = 'prettier' in packageJson.devDependencies;
 		workspace.kit.installed = '@sveltejs/kit' in packageJson.devDependencies;
 		workspace.dependencies = { ...packageJson.devDependencies, ...packageJson.dependencies };

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -14,7 +14,7 @@
 	],
 	"dependencies": {
 		"playwright": "^1.44.1",
-		"create-svelte": "^6.3.0"
+		"create-svelte": "^6.3.4"
 	},
 	"devDependencies": {
 		"promise-parallel-throttle": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       create-svelte:
-        specifier: ^6.3.0
-        version: 6.3.2
+        specifier: ^6.3.4
+        version: 6.3.4
       playwright:
         specifier: ^1.44.1
         version: 1.45.0
@@ -1233,8 +1233,8 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
-  create-svelte@6.3.2:
-    resolution: {integrity: sha512-9Ipg3qO9GJWbup2UHhAqL31sT3p8606CIWZBjorq2jNN7cbVdY0MxaghgyG3hZl5zq2NC6QztCGZPJLGVPTjyw==}
+  create-svelte@6.3.4:
+    resolution: {integrity: sha512-QDQJXkkq6SGP//gfjmW0UhGJEgZfYVS8Qy40tKtyt9RClumQjndQjESMNWlisU67CknV6nt6u40lTv0HA+QPkw==}
     hasBin: true
 
   cross-spawn@5.1.0:
@@ -4121,7 +4121,7 @@ snapshots:
 
   cookie@0.6.0: {}
 
-  create-svelte@6.3.2:
+  create-svelte@6.3.4:
     dependencies:
       '@clack/prompts': 0.7.0
       kleur: 4.1.5


### PR DESCRIPTION
In https://github.com/sveltejs/kit/pull/12453 `tslib` got removed, which broke our typescript detection. If we now detect a `tsconfig.json` or a `vite.config.json` in the current or any of the upwards directories, we assume that we have typescript project.