### PR TITLE
fix: self closing tags

### DIFF
--- a/.changeset/heavy-carpets-roll.md
+++ b/.changeset/heavy-carpets-roll.md
@@ -1,0 +1,5 @@
+---
+'@svelte-add/ast-tooling': patch
+---
+
+fix: self closing tags

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -1,8 +1,8 @@
 import { parse as tsParse } from 'recast/parsers/typescript.js';
 import { parse as recastParse, print as recastPrint } from 'recast';
-import { Document, Element, Text, type ChildNode } from 'domhandler';
+import { Document, Element, type ChildNode } from 'domhandler';
 import { ElementType, parseDocument } from 'htmlparser2';
-import { appendChild, prependChild, removeElement, textContent } from 'domutils';
+import { removeElement, textContent } from 'domutils';
 import serializeDom from 'dom-serializer';
 import {
 	Root as CssAst,


### PR DESCRIPTION
Closes #507 

We need to enable `xmlMode` of [`dom-serializer`](https://www.npmjs.com/package/dom-serializer) to make this work. According to https://github.com/cheeriojs/dom-serializer/issues/727 otherwise only void html tags like `br` will be self closing.

As you can assume by the naming of `xmlMode` it does not work well if there are nodes containing non xml code like JS or CSS that will be serialized (it produces complete garbage). That's why for svelte files we need to serialize JS, HTML, CSS first and then concatenate them together. 

Using the example given in the issue (`create-svelte` demo app, applying `tailwindcss` adder) and assuming the user opted in to install prettier, this now produces an empty diff (nothing changed). If prettier was not installed I also find the diff more acceptable than previously. 
![image](https://github.com/user-attachments/assets/f6489228-5c91-4e55-8ebb-693ba69bd97b)
