### PR TITLE
chore: add `svelte-add` script for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,13 +46,13 @@ pnpm changeset
 The easiest way to test a adder is to run it's cli directly.
 
 ```sh
-npx ./adders/bulma
+pnpm svelte-add tailwindcss
 ```
 
 Alternatively you can also run the testsuite of a adder with this command:
 
 ```sh
-pnpm test bulma mdsvex
+pnpm test tailwindcss mdsvex
 ```
 
 And if you have made changes to the core packages, you should probably run the full test suite for all adders. But keep in mind, this takes time!

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"rollup-plugin-dts": "^6.1.1",
 		"rollup-plugin-esbuild": "^6.1.1",
 		"rollup-plugin-preserve-shebangs": "^0.2.0",
+		"svelte-add": "workspace:*",
 		"typescript": "^5.5.2",
 		"typescript-eslint": "8.0.0-alpha.37"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       rollup-plugin-preserve-shebangs:
         specifier: ^0.2.0
         version: 0.2.0(rollup@4.18.0)
+      svelte-add:
+        specifier: workspace:*
+        version: link:packages/cli
       typescript:
         specifier: ^5.5.2
         version: 5.5.2


### PR DESCRIPTION
Make it easier to remember how to test an adder. 
Instead of using `node .\packages\cli\build\index.js` you can now use `pnpm svelte-add`