### PR TITLE
chore: Speed up tests

### DIFF
--- a/.changeset/clever-moons-buy.md
+++ b/.changeset/clever-moons-buy.md
@@ -1,0 +1,5 @@
+---
+'@svelte-add/testing-library': patch
+---
+
+chore: restructured execution order of tests

--- a/adders/storybook/config/tests.ts
+++ b/adders/storybook/config/tests.ts
@@ -1,14 +1,15 @@
 import { defineAdderTests } from '@svelte-add/core';
 import { options } from './options.js';
 
+let port = 6006;
+
 export const tests = defineAdderTests({
 	options,
 	optionValues: [],
-	// If you run multiple of these tests in parallel, most of the times randomly one test
-	// will fail while executing some npx command with an exit code of 7.
-	// In order to get consistent results, we execute those tests one after the other.
-	runSynchronously: true,
-	command: 'storybook',
+	get command() {
+		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+		return `storybook -p ${port++}`;
+	},
 	files: [],
 	tests: [
 		{

--- a/packages/testing-library/utils/browser-control.ts
+++ b/packages/testing-library/utils/browser-control.ts
@@ -1,7 +1,12 @@
-import { chromium, type Browser, type Page } from 'playwright';
+import { chromium, type Browser } from 'playwright';
 
-export async function startBrowser(url: string, headless: boolean) {
-	const browser = await chromium.launch({ headless });
+let browser: Browser;
+
+export async function startBrowser(headless: boolean) {
+	browser = await chromium.launch({ headless });
+}
+
+export async function openPage(url: string) {
 	const page = await browser.newPage();
 
 	await page.goto(url, { timeout: 60_000 });
@@ -11,10 +16,9 @@ export async function startBrowser(url: string, headless: boolean) {
 	// of each developer and thus leads to inconsistent test results.
 	await page.emulateMedia({ colorScheme: 'light' });
 
-	return { browser, page };
+	return { page };
 }
 
-export async function stopBrowser(browser: Browser, page: Page) {
-	await page.close();
+export async function stopBrowser() {
 	await browser.close();
 }

--- a/packages/testing-library/utils/browser-control.ts
+++ b/packages/testing-library/utils/browser-control.ts
@@ -16,7 +16,7 @@ export async function openPage(url: string) {
 	// of each developer and thus leads to inconsistent test results.
 	await page.emulateMedia({ colorScheme: 'light' });
 
-	return { page };
+	return page;
 }
 
 export async function stopBrowser() {

--- a/packages/testing-library/utils/test-cases.ts
+++ b/packages/testing-library/utils/test-cases.ts
@@ -91,7 +91,7 @@ export async function executeAdderTests(
 	testOptions: TestOptions,
 ) {
 	const { url, devServer } = await startDevServer(workingDirectory, adder.tests?.command ?? 'dev');
-	const { page } = await openPage(url);
+	const page = await openPage(url);
 
 	try {
 		const errorOcurred = await page.$('vite-error-overlay');

--- a/packages/testing-library/utils/workspace.ts
+++ b/packages/testing-library/utils/workspace.ts
@@ -12,9 +12,7 @@ export function getTemplatesDirectory(options: TestOptions) {
 
 export async function installDependencies(output: string) {
 	try {
-		// Since tests are executed and installed within this repo (packages/tests/.outputs),
-		// we need to add the `--ignore-workspace` flag so that our root lockfile isn't modified
-		await executeCli('pnpm', ['install', '--ignore-workspace'], output, { stdio: 'pipe' });
+		await executeCli('pnpm', ['install'], output, { stdio: 'pipe' });
 	} catch (error) {
 		const typedError = error as Error;
 		throw new Error('unable to install dependencies: ' + typedError.message);


### PR DESCRIPTION
This PR is more of an experiment to see if this can speedup our current test suite. 

Rather than having each test case be it's own individual project, we'll just setup the `.outputs` directory as an pnpm workspace. Additionally, instead of running `pnpm install` for each test case (which takes a notable amount of time, even when pnpm doesn't have to download anything), we'll just run the install command once at the root after executing all of the adders. 

This change has a pretty nice impact locally, so I'm interested in seeing the effects in CI.

Also includes:
- Using a single browser instance with new pages rather than destroying and creating a new browser on every test case
- Fixed storybook test so that it can run asynchronously (the main issue was that the same port `6006` was being used across all test cases. making them unique fixes this)

---

- [x] ~~annoyingly, storybook is causing some of the tests to fail. removing it lets everything else to pass. looking into it~~

looks to be ~24% faster:
Before **(6m 11s)**: https://github.com/svelte-add/svelte-add/actions/runs/10237434004/job/28320721634
After **(4m 44s)**: https://github.com/svelte-add/svelte-add/actions/runs/10255048750/job/28371145721

After additional changes **(4m 10s)**: https://github.com/svelte-add/svelte-add/actions/runs/10257333450/job/28378185485

pretty decent!