### PR TITLE
chore: use `defineConfig` for playwright adder

### DIFF
--- a/.changeset/tender-baboons-raise.md
+++ b/.changeset/tender-baboons-raise.md
@@ -1,0 +1,6 @@
+---
+'@svelte-add/adders': patch
+'svelte-add': patch
+---
+
+chore: use `defineConfig` helper for `playwright`


### PR DESCRIPTION
Didn't realize playwright exported their own `defineConfig` helper function for configs. Using this instead will allow the JS and TS versions of the config be identical.