### PR TITLE
fix: pin `storybook` version and faster testing

### DIFF
--- a/.changeset/gorgeous-seahorses-repeat.md
+++ b/.changeset/gorgeous-seahorses-repeat.md
@@ -1,0 +1,5 @@
+---
+'@svelte-add/adders': patch
+---
+
+fix: pinned `storybook` cli version

--- a/.changeset/six-parrots-tan.md
+++ b/.changeset/six-parrots-tan.md
@@ -1,0 +1,5 @@
+---
+'@svelte-add/testing-library': patch
+---
+
+fix: empty test cases are no longer needed

--- a/adders/eslint/config/tests.ts
+++ b/adders/eslint/config/tests.ts
@@ -5,10 +5,5 @@ export const tests = defineAdderTests({
 	files: [],
 	options,
 	optionValues: [],
-	tests: [
-		{
-			name: '',
-			run: async () => {},
-		},
-	],
+	tests: [],
 });

--- a/adders/playwright/config/tests.ts
+++ b/adders/playwright/config/tests.ts
@@ -5,10 +5,5 @@ export const tests = defineAdderTests({
 	files: [],
 	options,
 	optionValues: [],
-	tests: [
-		{
-			name: '',
-			run: async () => {},
-		},
-	],
+	tests: [],
 });

--- a/adders/prettier/config/tests.ts
+++ b/adders/prettier/config/tests.ts
@@ -5,10 +5,5 @@ export const tests = defineAdderTests({
 	files: [],
 	options,
 	optionValues: [],
-	tests: [
-		{
-			name: '',
-			run: async () => {},
-		},
-	],
+	tests: [],
 });

--- a/adders/storybook/config/adder.ts
+++ b/adders/storybook/config/adder.ts
@@ -23,5 +23,5 @@ export const adder = defineAdderConfig({
 
 	options,
 	integrationType: 'external',
-	command: 'storybook@next init --skip-install --no-dev',
+	command: 'storybook@8.3.0-alpha.3 init --skip-install --no-dev',
 });

--- a/adders/storybook/config/tests.ts
+++ b/adders/storybook/config/tests.ts
@@ -8,9 +8,18 @@ export const tests = defineAdderTests({
 	optionValues: [],
 	get command() {
 		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-		return `storybook -p ${port++}`;
+		return `storybook -p ${port++} --ci`;
 	},
-	files: [],
+	files: [
+		// hack to prevent this build script from running
+		{
+			name: () => 'package.json',
+			contentType: 'json',
+			content: ({ data }) => {
+				delete data.scripts.build;
+			},
+		},
+	],
 	tests: [
 		{
 			name: 'storybook loaded',

--- a/adders/storybook/config/tests.ts
+++ b/adders/storybook/config/tests.ts
@@ -10,16 +10,7 @@ export const tests = defineAdderTests({
 		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 		return `storybook -p ${port++} --ci`;
 	},
-	files: [
-		// hack to prevent this build script from running
-		{
-			name: () => 'package.json',
-			contentType: 'json',
-			content: ({ data }) => {
-				delete data.scripts.build;
-			},
-		},
-	],
+	files: [],
 	tests: [
 		{
 			name: 'storybook loaded',

--- a/adders/vitest/config/tests.ts
+++ b/adders/vitest/config/tests.ts
@@ -5,10 +5,5 @@ export const tests = defineAdderTests({
 	files: [],
 	options,
 	optionValues: [],
-	tests: [
-		{
-			name: '',
-			run: async () => {},
-		},
-	],
+	tests: [],
 });

--- a/packages/testing-library/utils/test-cases.ts
+++ b/packages/testing-library/utils/test-cases.ts
@@ -125,11 +125,10 @@ export async function runTestCases(testCases: Map<string, TestCase[]>, testOptio
 	const tests: { testCase: TestCase; cwd: string }[] = [];
 
 	console.log('executing adders');
-	const setups = [];
-	for (const values of testCases.values()) {
-		for (const testCase of values) {
-			if (testCase.adder.tests?.tests.length === 0) continue;
+	const setups = Array.from(testCases.values()).flatMap((values) =>
+		values.map((testCase) => {
 			const task = async () => {
+				if (testCase.adder.tests?.tests.length === 0) return;
 				const cwd = await setupAdder(
 					testCase.template,
 					testCase.adder,
@@ -138,10 +137,9 @@ export async function runTestCases(testCases: Map<string, TestCase[]>, testOptio
 				);
 				tests.push({ testCase, cwd });
 			};
-
-			setups.push(task());
-		}
-	}
+			return task();
+		}),
+	);
 
 	await Promise.all(setups);
 

--- a/packages/testing-library/utils/test-cases.ts
+++ b/packages/testing-library/utils/test-cases.ts
@@ -6,7 +6,6 @@ import { uid } from 'uid';
 import { startDevServer, stopDevServer } from './dev-server';
 import { openPage, startBrowser, stopBrowser } from './browser-control';
 import {
-	buildProjects,
 	getTemplatesDirectory,
 	installDependencies,
 	prepareWorkspaceWithTemplate,
@@ -93,7 +92,7 @@ export async function executeAdderTests(
 ) {
 	if (!adder.tests) return;
 
-	const cmd = adder.tests.command ?? 'preview';
+	const cmd = adder.tests.command ?? 'dev';
 	const { url, devServer } = await startDevServer(workingDirectory, cmd);
 	const page = await openPage(url);
 
@@ -148,9 +147,6 @@ export async function runTestCases(testCases: Map<string, TestCase[]>, testOptio
 
 	console.log('installing dependencies');
 	await installDependencies(testOptions.outputDirectory);
-
-	console.log('building projects');
-	await buildProjects(testOptions.outputDirectory);
 
 	await startBrowser(testOptions.headless);
 

--- a/packages/testing-library/utils/workspace.ts
+++ b/packages/testing-library/utils/workspace.ts
@@ -19,6 +19,15 @@ export async function installDependencies(output: string) {
 	}
 }
 
+export async function buildProjects(output: string) {
+	try {
+		await executeCli('pnpm', ['--parallel', 'run', 'build'], output, { stdio: 'pipe' });
+	} catch (error) {
+		const typedError = error as Error;
+		throw new Error('unable to build projects: ' + typedError.message);
+	}
+}
+
 export async function prepareWorkspaceWithTemplate(
 	output: string,
 	template: string,

--- a/packages/testing-library/utils/workspace.ts
+++ b/packages/testing-library/utils/workspace.ts
@@ -19,15 +19,6 @@ export async function installDependencies(output: string) {
 	}
 }
 
-export async function buildProjects(output: string) {
-	try {
-		await executeCli('pnpm', ['--parallel', 'run', 'build'], output, { stdio: 'pipe' });
-	} catch (error) {
-		const typedError = error as Error;
-		throw new Error('unable to build projects: ' + typedError.message);
-	}
-}
-
 export async function prepareWorkspaceWithTemplate(
 	output: string,
 	template: string,


### PR DESCRIPTION
Temporarily pinning the storybook version until https://github.com/storybookjs/storybook/issues/28819 is resolved.

I've also added a small tweak to make the tests run just [a tiny bit faster too](https://github.com/svelte-add/svelte-add/actions/runs/10291840325/job/28484994433) **(3m 43s)**