### PR TITLE
chore: publish package provenance info

### DIFF
--- a/.changeset/cuddly-tips-trade.md
+++ b/.changeset/cuddly-tips-trade.md
@@ -1,0 +1,10 @@
+---
+'@svelte-add/ast-manipulation': patch
+'@svelte-add/testing-library': patch
+'@svelte-add/ast-tooling': patch
+'@svelte-add/config': patch
+'@svelte-add/core': patch
+'svelte-add': patch
+---
+
+chore: publish package provenance info

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,8 +5,9 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write # to create release (changesets/action)
+  id-token: write # OpenID Connect token needed for provenance
+  pull-requests: write # to create pull request (changesets/action)
 
 jobs:
   version:

--- a/packages/ast-manipulation/package.json
+++ b/packages/ast-manipulation/package.json
@@ -24,5 +24,8 @@
 		"type": "git",
 		"url": "https://github.com/svelte-add/svelte-add/tree/main/projects/ast-manipulation"
 	},
-	"keywords": []
+	"keywords": [],
+	"publishConfig": {
+		"provenance": true
+	}
 }

--- a/packages/ast-tooling/package.json
+++ b/packages/ast-tooling/package.json
@@ -29,5 +29,8 @@
 		"type": "git",
 		"url": "https://github.com/svelte-add/svelte-add/tree/main/projects/ast-tooling"
 	},
-	"keywords": []
+	"keywords": [],
+	"publishConfig": {
+		"provenance": true
+	}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,5 +13,8 @@
 	"devDependencies": {
 		"@svelte-add/adders": "workspace:*",
 		"commander": "^12.1.0"
+	},
+	"publishConfig": {
+		"provenance": true
 	}
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,5 +14,8 @@
 		"type": "git",
 		"url": "https://github.com/svelte-add/svelte-add/tree/main/projects/config"
 	},
-	"keywords": []
+	"keywords": [],
+	"publishConfig": {
+		"provenance": true
+	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,5 +38,8 @@
 		"svelte",
 		"kit",
 		"svelte-kit"
-	]
+	],
+	"publishConfig": {
+		"provenance": true
+	}
 }

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -34,5 +34,8 @@
 		"svelte",
 		"kit",
 		"svelte-kit"
-	]
+	],
+	"publishConfig": {
+		"provenance": true
+	}
 }


### PR DESCRIPTION
I tested this on SvelteKit already. Now we have a nice little green checkmark next to the version on npm