### PR TITLE
feat: Lucia Adder

### DIFF
--- a/.changeset/grumpy-camels-return.md
+++ b/.changeset/grumpy-camels-return.md
@@ -1,0 +1,5 @@
+---
+'@svelte-add/core': minor
+---
+
+feat: add `dependsOn` adder option for adders that depend on each other

--- a/.changeset/large-geese-search.md
+++ b/.changeset/large-geese-search.md
@@ -1,0 +1,7 @@
+---
+'@svelte-add/config': minor
+'@svelte-add/adders': minor
+'svelte-add': minor
+---
+
+feat: `lucia` adder

--- a/.changeset/young-crews-rule.md
+++ b/.changeset/young-crews-rule.md
@@ -1,0 +1,5 @@
+---
+'@svelte-add/ast-manipulation': patch
+---
+
+chore: add named import merging

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -22,12 +22,12 @@ export const adder = defineAdderConfig({
 	options: availableOptions,
 	integrationType: 'inline',
 	packages: [
-		{ name: 'drizzle-orm', version: '^0.31.2', dev: false },
-		{ name: 'drizzle-kit', version: '^0.22.0', dev: true },
+		{ name: 'drizzle-orm', version: "^0.33.0", dev: false },
+		{ name: 'drizzle-kit', version: "^0.24.0", dev: true },
 		// MySQL
 		{
 			name: 'mysql2',
-			version: '^3.9.8',
+			version: "^3.11.0",
 			dev: false,
 			condition: ({ options }) => options.mysql === 'mysql2',
 		},
@@ -40,7 +40,7 @@ export const adder = defineAdderConfig({
 		// PostgreSQL
 		{
 			name: '@neondatabase/serverless',
-			version: '^0.9.3',
+			version: "^0.9.4",
 			dev: false,
 			condition: ({ options }) => options.postgresql === 'neon',
 		},
@@ -53,19 +53,19 @@ export const adder = defineAdderConfig({
 		// SQLite
 		{
 			name: 'better-sqlite3',
-			version: '^10.0.0',
+			version: "^11.1.2",
 			dev: false,
 			condition: ({ options }) => options.sqlite === 'better-sqlite3',
 		},
 		{
 			name: '@types/better-sqlite3',
-			version: '^7.6.10',
+			version: "^7.6.11",
 			dev: true,
 			condition: ({ options }) => options.sqlite === 'better-sqlite3',
 		},
 		{
 			name: '@libsql/client',
-			version: '^0.6.1',
+			version: "^0.9.0",
 			dev: false,
 			condition: ({ options }) => options.sqlite === 'libsql' || options.sqlite === 'turso',
 		},

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -22,12 +22,12 @@ export const adder = defineAdderConfig({
 	options: availableOptions,
 	integrationType: 'inline',
 	packages: [
-		{ name: 'drizzle-orm', version: "^0.33.0", dev: false },
-		{ name: 'drizzle-kit', version: "^0.24.0", dev: true },
+		{ name: 'drizzle-orm', version: '^0.33.0', dev: false },
+		{ name: 'drizzle-kit', version: '^0.24.0', dev: true },
 		// MySQL
 		{
 			name: 'mysql2',
-			version: "^3.11.0",
+			version: '^3.11.0',
 			dev: false,
 			condition: ({ options }) => options.mysql === 'mysql2',
 		},
@@ -40,7 +40,7 @@ export const adder = defineAdderConfig({
 		// PostgreSQL
 		{
 			name: '@neondatabase/serverless',
-			version: "^0.9.4",
+			version: '^0.9.4',
 			dev: false,
 			condition: ({ options }) => options.postgresql === 'neon',
 		},
@@ -53,19 +53,19 @@ export const adder = defineAdderConfig({
 		// SQLite
 		{
 			name: 'better-sqlite3',
-			version: "^11.1.2",
+			version: '^11.1.2',
 			dev: false,
 			condition: ({ options }) => options.sqlite === 'better-sqlite3',
 		},
 		{
 			name: '@types/better-sqlite3',
-			version: "^7.6.11",
+			version: '^7.6.11',
 			dev: true,
 			condition: ({ options }) => options.sqlite === 'better-sqlite3',
 		},
 		{
 			name: '@libsql/client',
-			version: "^0.9.0",
+			version: '^0.9.0',
 			dev: false,
 			condition: ({ options }) => options.sqlite === 'libsql' || options.sqlite === 'turso',
 		},

--- a/adders/drizzle/config/adder.ts
+++ b/adders/drizzle/config/adder.ts
@@ -211,7 +211,6 @@ export const adder = defineAdderConfig({
 
 					userSchemaExpression = common.expressionFromString(`sqliteTable('user', {
                         id: integer('id').primaryKey(),
-                        name: text('name').notNull(),
                         age: integer('age')
                     })`);
 				}
@@ -225,7 +224,6 @@ export const adder = defineAdderConfig({
 
 					userSchemaExpression = common.expressionFromString(`mysqlTable('user', {
                         id: serial("id").primaryKey(),
-                        name: text('name').notNull(),
                         age: int('age'),
                     })`);
 				}
@@ -239,7 +237,6 @@ export const adder = defineAdderConfig({
 
 					userSchemaExpression = common.expressionFromString(`pgTable('user', {
                         id: serial('id').primaryKey(),
-                        name: text('name').notNull(),
                         age: integer('age'),
                     })`);
 				}

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -170,7 +170,7 @@ export const adder = defineAdderConfig({
 
 				// adapter
 				const adapterDecl = common.statementFromString(
-					`const adapter = new ${adapter}(db, user, session);`,
+					`const adapter = new ${adapter}(db, session, user);`,
 				);
 				common.addStatement(ast, adapterDecl);
 

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -504,22 +504,20 @@ function getAuthHandleContent() {
 			}
 
 			const { session, user } = await lucia.validateSession(sessionId);
-			if (session && session.fresh) {
-				const sessionCookie = lucia.createSessionCookie(session.id);
+			if (!session || session.fresh) {
+				const sessionCookie = !session
+					? lucia.createBlankSessionCookie()
+					: lucia.createSessionCookie(session.id);
+
 				event.cookies.set(sessionCookie.name, sessionCookie.value, {
 					path: ".",
-					...sessionCookie.attributes
+					...sessionCookie.attributes,
 				});
 			}
-			if (!session) {
-				const sessionCookie = lucia.createBlankSessionCookie();
-				event.cookies.set(sessionCookie.name, sessionCookie.value, {
-					path: ".",
-					...sessionCookie.attributes
-				});
-			}
+
 			event.locals.user = user;
 			event.locals.session = session;
+
 			return resolve(event);
 		};`;
 }

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -250,31 +250,7 @@ export const adder = defineAdderConfig({
 			name: ({ typescript }) => `src/hooks.server.${typescript.installed ? 'ts' : 'js'}`,
 			contentType: 'script',
 			content: ({ ast, imports, exports, common, object }) => {
-				const defineConfig = common.expressionFromString('defineConfig({})');
-				const defaultExport = exports.defaultExport(ast, defineConfig);
-
-				const config = {
-					webServer: object.create({
-						command: common.createLiteral('npm run build && npm run preview'),
-						port: common.expressionFromString('4173'),
-					}),
-					testDir: common.createLiteral('e2e'),
-				};
-
-				if (
-					defaultExport.value.type === 'CallExpression' &&
-					defaultExport.value.arguments[0].type === 'ObjectExpression'
-				) {
-					// uses the `defineConfig` helper
-					imports.addNamed(ast, '@playwright/test', { defineConfig: 'defineConfig' });
-					object.properties(defaultExport.value.arguments[0], config);
-				} else if (defaultExport.value.type === 'ObjectExpression') {
-					// if the config is just an object expression, just add the property
-					object.properties(defaultExport.value, config);
-				} else {
-					// unexpected config shape
-					log.warn('Unexpected playwright config for playwright adder. Could not update.');
-				}
+				// TODO
 			},
 		},
 	],

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -202,6 +202,7 @@ export const adder = defineAdderConfig({
 			// TODO: comments aren't preserved for some reason
 			// TODO: replace console logs for errors or warnings
 			name: () => `src/app.d.ts`,
+			condition: ({ typescript }) => typescript.installed,
 			contentType: 'script',
 			content: ({ ast, common }) => {
 				const global = ast.body

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -1,4 +1,4 @@
-import { defineAdderConfig, log, Walker, type AstTypes } from '@svelte-add/core';
+import { defineAdderConfig, log, Walker, type AstKinds, type AstTypes } from '@svelte-add/core';
 import { options } from './options.js';
 
 const LUCIA_ADAPTER = {
@@ -62,8 +62,8 @@ export const adder = defineAdderConfig({
 			name: () => schemaPath,
 			contentType: 'script',
 			content: ({ ast, common, exports, imports, object, variables }) => {
-				let userInit;
-				let sessionInit;
+				let userInit: AstKinds.ExpressionKind | undefined;
+				let sessionInit: AstKinds.ExpressionKind | undefined;
 				if (drizzleDialect === 'sqlite') {
 					imports.addNamed(ast, 'drizzle-orm/sqlite-core', {
 						sqliteTable: 'sqliteTable',
@@ -114,6 +114,11 @@ export const adder = defineAdderConfig({
 							userId: text("user_id").notNull().references(() => user.id),
 							expiresAt: timestamp("expires_at", { withTimezone: true, mode: "date" }).notNull()
 						});`);
+				}
+
+				if (!userInit || !sessionInit) {
+					// TODO: invalid dialects
+					return;
 				}
 
 				const userDecl = variables.declaration(ast, 'const', 'user', userInit);

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -30,6 +30,7 @@ export const adder = defineAdderConfig({
 		{ name: 'lucia', version: '^3.2.0', dev: false },
 		{ name: '@lucia-auth/adapter-drizzle', version: '^1.1.0', dev: false },
 	],
+	runsAfter: ['drizzle'],
 	files: [
 		{
 			name: ({ typescript }) => `drizzle.config.${typescript.installed ? 'ts' : 'js'}`,

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -1,4 +1,4 @@
-import { defineAdderConfig, log, Walker, type AstKinds, type AstTypes } from '@svelte-add/core';
+import { defineAdderConfig, Walker, type AstKinds, type AstTypes } from '@svelte-add/core';
 import { options } from './options.js';
 
 const LUCIA_ADAPTER = {
@@ -192,6 +192,8 @@ export const adder = defineAdderConfig({
 						declare module "lucia" {
 							interface Register {
 								Lucia: typeof lucia;
+								DatabaseUserAttributes: typeof user.$inferSelect;
+								DatabaseSessionAttributes: typeof session.$inferSelect;
 							}
 						}`);
 					common.addStatement(ast, moduleDecl);

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -292,8 +292,8 @@ export const adder = defineAdderConfig({
 							handleName = handleSpecifier.local?.name ?? handleSpecifier.exported.name;
 
 							// find the definition
-							const handleFunc = ast.body.find((n) => isFunctionDeclarationHandle(n, handleName));
-							const handleVar = ast.body.find((n) => isVariableDeclarationHandle(n, handleName));
+							const handleFunc = ast.body.find((n) => isFunctionDeclaration(n, handleName));
+							const handleVar = ast.body.find((n) => isVariableDeclaration(n, handleName));
 
 							maybeHandleDecl = handleFunc ?? handleVar;
 						}
@@ -301,13 +301,13 @@ export const adder = defineAdderConfig({
 						maybeHandleDecl ??= node.declaration ?? undefined;
 
 						// `export const handle`
-						if (maybeHandleDecl && isVariableDeclarationHandle(maybeHandleDecl, handleName)) {
+						if (maybeHandleDecl && isVariableDeclaration(maybeHandleDecl, handleName)) {
 							exportDecl = node;
 							originalHandleDecl = maybeHandleDecl;
 						}
 
 						// `export function handle`
-						if (maybeHandleDecl && isFunctionDeclarationHandle(maybeHandleDecl, handleName)) {
+						if (maybeHandleDecl && isFunctionDeclaration(maybeHandleDecl, handleName)) {
 							exportDecl = node;
 							originalHandleDecl = maybeHandleDecl;
 						}
@@ -386,14 +386,14 @@ export const adder = defineAdderConfig({
 				imports.addNamed(ast, '@sveltejs/kit/hooks', { sequence: 'sequence' });
 
 				// rename `export const handle`
-				if (originalHandleDecl && isVariableDeclarationHandle(originalHandleDecl, handleName)) {
+				if (originalHandleDecl && isVariableDeclaration(originalHandleDecl, handleName)) {
 					const handle = getVariableDeclarator(originalHandleDecl, handleName);
 					if (handle && handle.id.type === 'Identifier') {
 						handle.id.name = NEW_HANDLE_NAME;
 					}
 				}
 				// rename `export function handle`
-				if (originalHandleDecl && isFunctionDeclarationHandle(originalHandleDecl, handleName)) {
+				if (originalHandleDecl && isFunctionDeclaration(originalHandleDecl, handleName)) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					originalHandleDecl.id!.name = NEW_HANDLE_NAME;
 				}
@@ -466,16 +466,12 @@ function usingSequence(node: AstTypes.VariableDeclarator, handleName: string) {
 	);
 }
 
-function isVariableDeclarationHandle(
+function isVariableDeclaration(
 	node: AstTypes.ASTNode,
-	handleName: string,
+	variableName: string,
 ): node is AstTypes.VariableDeclaration {
 	return (
-		node.type === 'VariableDeclaration' &&
-		node.declarations.some(
-			(d) =>
-				d.type === 'VariableDeclarator' && d.id.type === 'Identifier' && d.id.name === handleName,
-		)
+		node.type === 'VariableDeclaration' && getVariableDeclarator(node, variableName) !== undefined
 	);
 }
 
@@ -489,11 +485,11 @@ function getVariableDeclarator(
 	) as AstTypes.VariableDeclarator | undefined;
 }
 
-function isFunctionDeclarationHandle(
+function isFunctionDeclaration(
 	node: AstTypes.ASTNode,
-	handleName: string,
+	funcName: string,
 ): node is AstTypes.FunctionDeclaration {
-	return node.type === 'FunctionDeclaration' && node.id?.name === handleName;
+	return node.type === 'FunctionDeclaration' && node.id?.name === funcName;
 }
 
 function getAuthHandleContent() {

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -160,7 +160,7 @@ export const adder = defineAdderConfig({
 					object.overrideProperties(sessionAttributes, {
 						id: common.expressionFromString(`varchar('id', { length: 255 }).primaryKey()`),
 						userId: common.expressionFromString(
-							`varchar('id', { length: 255 }).notNull().references(() => user.id)`,
+							`varchar('user_id', { length: 255 }).notNull().references(() => user.id)`,
 						),
 						expiresAt: common.expressionFromString(`datetime("expires_at").notNull()`),
 					});

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -315,6 +315,7 @@ export const adder = defineAdderConfig({
 				});
 
 				const authHandle = common.expressionFromString(getAuthHandleContent());
+				if (common.hasNode(ast, authHandle)) return;
 
 				// This is the straightforward case. If there's no existing `handle`, we'll just add one
 				// with the `auth` handle's definition and exit

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -52,6 +52,7 @@ export const adder = defineAdderConfig({
 		},
 	],
 	runsAfter: ['drizzle'],
+	dependsOn: ['drizzle'],
 	files: [
 		{
 			name: ({ typescript }) => `drizzle.config.${typescript.installed ? 'ts' : 'js'}`,
@@ -240,8 +241,6 @@ export const adder = defineAdderConfig({
 			},
 		},
 		{
-			// TODO: comments aren't preserved for some reason
-			// TODO: replace console logs for errors or warnings
 			name: () => `src/app.d.ts`,
 			condition: ({ typescript }) => typescript.installed,
 			contentType: 'script',

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -1,0 +1,312 @@
+import { defineAdderConfig, log, Walker, type AstTypes } from '@svelte-add/core';
+import { options } from './options.js';
+
+const LUCIA_ADAPTER = {
+	mysql: 'DrizzleMySQLAdapter',
+	postgresql: 'DrizzlePostgreSQLAdapter',
+	sqlite: 'DrizzleSQLiteAdapter',
+} as const;
+
+type Dialect = keyof typeof LUCIA_ADAPTER;
+
+let drizzleDialect: Dialect;
+let schemaPath: string;
+
+export const adder = defineAdderConfig({
+	metadata: {
+		id: 'lucia',
+		name: 'Lucia',
+		description: 'An auth library that abstracts away the complexity of handling sessions',
+		environments: { svelte: false, kit: true },
+		website: {
+			logo: './lucia.svg',
+			keywords: ['lucia', 'lucia-auth', 'auth', 'authentication'],
+			documentation: 'https://lucia-auth.com',
+		},
+	},
+	options,
+	integrationType: 'inline',
+	packages: [
+		{ name: 'lucia', version: '^3.2.0', dev: false },
+		{ name: '@lucia-auth/adapter-drizzle', version: '^1.1.0', dev: false },
+	],
+	files: [
+		{
+			name: ({ typescript }) => `drizzle.config.${typescript.installed ? 'ts' : 'js'}`,
+			contentType: 'script',
+			content: ({ ast }) => {
+				const isProp = (name: string, node: AstTypes.ObjectProperty) =>
+					node.key.type === 'Identifier' && node.key.name === name;
+
+				// prettier-ignore
+				Walker.walk(ast as AstTypes.ASTNode, {}, {
+					ObjectProperty(node) {
+						if (isProp("dialect", node) && node.value.type === 'StringLiteral') {
+							drizzleDialect = node.value.value as Dialect;
+						}
+						if (isProp("schema", node) && node.value.type === 'StringLiteral') {
+							schemaPath = node.value.value;
+						}
+					}
+				})
+
+				if (!drizzleDialect) {
+					// TODO: failed to find dialect
+				}
+				if (!schemaPath) {
+					// TODO: failed to find schema path
+				}
+			},
+		},
+		{
+			name: () => schemaPath,
+			contentType: 'script',
+			content: ({ ast, common, exports, imports, object, variables }) => {
+				let userInit;
+				let sessionInit;
+				if (drizzleDialect === 'sqlite') {
+					imports.addNamed(ast, 'drizzle-orm/sqlite-core', {
+						sqliteTable: 'sqliteTable',
+						text: 'text',
+						integer: 'integer',
+					});
+					userInit = common.expressionFromString(`
+						sqliteTable('user', {
+							id: text('id').primaryKey(),
+						});`);
+					sessionInit = common.expressionFromString(`
+						sqliteTable('session', {
+							id: text('id').primaryKey(),
+							userId: text("user_id").notNull().references(() => user.id),
+							expiresAt: integer("expires_at").notNull()
+						});`);
+				}
+				if (drizzleDialect === 'mysql') {
+					imports.addNamed(ast, 'drizzle-orm/mysql-core', {
+						mysqlTable: 'mysqlTable',
+						varchar: 'varchar',
+						datetime: 'datetime',
+					});
+					userInit = common.expressionFromString(`
+						mysqlTable('user', {
+							id: varchar('id', { length: 255 }).primaryKey(),
+						});`);
+					sessionInit = common.expressionFromString(`
+						mysqlTable('session', {
+							id: varchar('id', { length: 255 }).primaryKey(),
+							userId: varchar('id', { length: 255 }).notNull().references(() => user.id),
+							expiresAt: datetime("expires_at").notNull()
+						});`);
+				}
+				if (drizzleDialect === 'postgresql') {
+					imports.addNamed(ast, 'drizzle-orm/pg-core', {
+						pgTable: 'pgTable',
+						text: 'text',
+						timestamp: 'timestamp',
+					});
+					userInit = common.expressionFromString(`
+						pgTable('user', {
+							id: text('id').primaryKey(),
+						});`);
+					sessionInit = common.expressionFromString(`
+						pgTable('session', {
+							id: text('id').primaryKey(),
+							userId: text("user_id").notNull().references(() => user.id),
+							expiresAt: timestamp("expires_at", { withTimezone: true, mode: "date" }).notNull()
+						});`);
+				}
+
+				const userDecl = variables.declaration(ast, 'const', 'user', userInit);
+				const sessionDecl = variables.declaration(ast, 'const', 'session', sessionInit);
+				const user = exports.namedExport(ast, 'user', userDecl);
+				const session = exports.namedExport(ast, 'session', sessionDecl);
+
+				// if (drizzleDialect === 'sqlite') {
+				// 	user.declaration?.type === 'VariableDeclaration' &&
+				// 		user.declaration.declarations[0].type === 'VariableDeclarator' &&
+				// 		user.declaration.declarations[0].object.properties(user, {
+				// 			id: common.expressionFromString(''),
+				// 		});
+				// 	object.properties(session, {
+				// 		id: common.expressionFromString(''),
+				// 		userId: common.expressionFromString(''),
+				// 	});
+				// }
+			},
+		},
+		{
+			name: ({ kit, typescript }) =>
+				`${kit.libDirectory}/server/auth.${typescript.installed ? 'ts' : 'js'}`,
+			contentType: 'script',
+			content: ({ ast, imports, common, exports, typescript, variables }) => {
+				const adapter = LUCIA_ADAPTER[drizzleDialect];
+
+				imports.addNamed(ast, '$lib/server/db/schema.js', { user: 'user', session: 'session' });
+				imports.addNamed(ast, '$lib/server/db', { db: 'db' });
+				imports.addNamed(ast, 'lucia', { Lucia: 'Lucia' });
+				imports.addNamed(ast, '@lucia-auth/adapter-drizzle', { [adapter]: adapter });
+				imports.addNamed(ast, '$app/environment', { dev: 'dev' });
+
+				// adapter
+				const adapterDecl = common.statementFromString(
+					`const adapter = new ${adapter}(db, user, session);`,
+				);
+				common.addStatement(ast, adapterDecl);
+
+				// lucia export
+				const luciaInit = common.expressionFromString(`
+					new Lucia(adapter, {
+						sessionCookie: {
+							attributes: {
+								secure: !dev
+							}
+						}
+					})`);
+				const luciaDecl = variables.declaration(ast, 'const', 'lucia', luciaInit);
+				exports.namedExport(ast, 'lucia', luciaDecl);
+
+				// module declaration
+				if (typescript.installed) {
+					const moduleDecl = common.statementFromString(`
+						declare module "lucia" {
+							interface Register {
+								Lucia: typeof lucia;
+							}
+						}`);
+					if (!common.hasNode(ast, moduleDecl)) {
+						common.addStatement(ast, moduleDecl);
+					}
+				}
+			},
+		},
+		{
+			// TODO: comments aren't preserved for some reason
+			// TODO: replace console logs for errors or warnings
+			name: () => `src/app.d.ts`,
+			contentType: 'script',
+			content: ({ ast, common }) => {
+				const global = ast.body
+					.filter((n) => n.type === 'TSModuleDeclaration')
+					.find((m) => m.global && m.declare);
+				if (!global) {
+					console.log('failed to find `declare global`');
+					return;
+				}
+
+				let app: AstTypes.TSModuleDeclaration | undefined;
+				let locals: AstTypes.TSInterfaceDeclaration | undefined;
+
+				// prettier-ignore
+				// get off my back, prettier
+				Walker.walk(global as AstTypes.ASTNode, {}, {
+					TSModuleDeclaration(node, { next }) {
+						if (node.id.type === 'Identifier' && node.id.name === 'App') {
+							app = node;
+						}
+						next();
+					},
+					TSInterfaceDeclaration(node) {
+						if (node.id.type === 'Identifier' && node.id.name === 'Locals') {
+							locals = node;
+						}
+					},
+				});
+
+				if (!app) {
+					console.log('missing `namespace App` declaration');
+					return;
+				}
+
+				if (app.body?.type !== 'TSModuleBlock') {
+					console.log('unexpected body type of `namespace App`');
+					return;
+				}
+
+				if (!locals) {
+					// add Locals interface it if it's missing
+					locals = common.statementFromString(
+						'interface Locals {}',
+					) as AstTypes.TSInterfaceDeclaration;
+					app.body.body.push(locals);
+				}
+
+				const user = locals.body.body.find((prop) => hasTypeProp('user', prop));
+				const session = locals.body.body.find((prop) => hasTypeProp('session', prop));
+
+				if (!user) {
+					locals.body.body.push(createLuciaType('user'));
+				}
+				if (!session) {
+					locals.body.body.push(createLuciaType('session'));
+				}
+			},
+		},
+		{
+			name: ({ typescript }) => `src/hooks.server.${typescript.installed ? 'ts' : 'js'}`,
+			contentType: 'script',
+			content: ({ ast, imports, exports, common, object }) => {
+				const defineConfig = common.expressionFromString('defineConfig({})');
+				const defaultExport = exports.defaultExport(ast, defineConfig);
+
+				const config = {
+					webServer: object.create({
+						command: common.createLiteral('npm run build && npm run preview'),
+						port: common.expressionFromString('4173'),
+					}),
+					testDir: common.createLiteral('e2e'),
+				};
+
+				if (
+					defaultExport.value.type === 'CallExpression' &&
+					defaultExport.value.arguments[0].type === 'ObjectExpression'
+				) {
+					// uses the `defineConfig` helper
+					imports.addNamed(ast, '@playwright/test', { defineConfig: 'defineConfig' });
+					object.properties(defaultExport.value.arguments[0], config);
+				} else if (defaultExport.value.type === 'ObjectExpression') {
+					// if the config is just an object expression, just add the property
+					object.properties(defaultExport.value, config);
+				} else {
+					// unexpected config shape
+					log.warn('Unexpected playwright config for playwright adder. Could not update.');
+				}
+			},
+		},
+	],
+});
+
+function createLuciaType(name: string): AstTypes.TSInterfaceBody['body'][number] {
+	return {
+		type: 'TSPropertySignature',
+		key: {
+			type: 'Identifier',
+			name,
+		},
+		typeAnnotation: {
+			type: 'TSTypeAnnotation',
+			typeAnnotation: {
+				type: 'TSUnionType',
+				types: [
+					{
+						type: 'TSImportType',
+						argument: { type: 'StringLiteral', value: 'lucia' },
+						qualifier: {
+							type: 'Identifier',
+							// capitalize first letter
+							name: `${name[0].toUpperCase()}${name.slice(1)}`,
+						},
+					},
+					{
+						type: 'TSNullKeyword',
+					},
+				],
+			},
+		},
+	};
+}
+
+function hasTypeProp(name: string, node: AstTypes.TSInterfaceDeclaration['body']['body'][number]) {
+	return (
+		node.type === 'TSPropertySignature' && node.key.type === 'Identifier' && node.key.name === name
+	);
+}

--- a/adders/lucia/config/adder.ts
+++ b/adders/lucia/config/adder.ts
@@ -380,17 +380,21 @@ export const adder = defineAdderConfig({
 					originalHandleDecl.id!.name = NEW_HANDLE_NAME;
 				}
 
+				// removes all declarations so that we can re-append them in the correct order
 				ast.body = ast.body.filter(
 					(n) => n !== originalHandleDecl && n !== exportDecl && n !== authDecl,
 				);
+
 				if (isSpecifier) {
 					ast.body.push(originalHandleDecl, authDecl, newHandleDecl, exportDecl);
 				}
 
 				if (exportDecl.declaration) {
-					// removes the `export` keyword from original `handle` declaration
-					// ast.body = ast.body.filter((n) => n !== exportDecl && n !== authDecl);
+					// when we re-append the declarations, we only want to add the declaration
+					// of the (now renamed) original `handle` _without_ the `export` keyword:
+					// e.g. `const originalHandle = ...;`
 					ast.body.push(exportDecl.declaration, authDecl);
+					// `export const handle = sequence(originalHandle, auth);`
 					exports.namedExport(ast, handleName, newHandleDecl);
 				}
 			},

--- a/adders/lucia/config/checks.ts
+++ b/adders/lucia/config/checks.ts
@@ -1,0 +1,6 @@
+import { defineAdderChecks } from '@svelte-add/core';
+import { options } from './options.js';
+
+export const checks = defineAdderChecks({
+	options,
+});

--- a/adders/lucia/config/options.ts
+++ b/adders/lucia/config/options.ts
@@ -1,0 +1,3 @@
+import { defineAdderOptions } from '@svelte-add/core';
+
+export const options = defineAdderOptions({});

--- a/adders/lucia/config/options.ts
+++ b/adders/lucia/config/options.ts
@@ -1,3 +1,9 @@
-import { defineAdderOptions } from '@svelte-add/core';
+import { defineAdderOptions, colors } from '@svelte-add/core';
 
-export const options = defineAdderOptions({});
+export const options = defineAdderOptions({
+	demo: {
+		type: 'boolean',
+		default: false,
+		question: `Do you want to include a demo? ${colors.dim('(includes a login/register page)')}`,
+	},
+});

--- a/adders/lucia/config/tests.ts
+++ b/adders/lucia/config/tests.ts
@@ -1,0 +1,9 @@
+import { defineAdderTests } from '@svelte-add/core';
+import { options } from './options.js';
+
+export const tests = defineAdderTests({
+	files: [],
+	options,
+	optionValues: [],
+	tests: [],
+});

--- a/adders/lucia/index.ts
+++ b/adders/lucia/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { defineAdder } from '@svelte-add/core';
+import { adder } from './config/adder.js';
+import { checks } from './config/checks.js';
+import { tests } from './config/tests.js';
+
+export default defineAdder(adder, checks, tests);

--- a/packages/ast-manipulation/js/common.ts
+++ b/packages/ast-manipulation/js/common.ts
@@ -53,11 +53,10 @@ export function areNodesEqual(ast1: AstTypes.ASTNode, ast2: AstTypes.ASTNode) {
 	// Without this, we'd be getting false negatives due to slight differences in formatting style.
 	// These ASTs are also filled to the brim with circular references, which prevents
 	// us from using `structuredCloned` directly
-	const ast1Clone = decircular(ast1);
-	const ast2Clone = decircular(ast2);
-	return (
-		serializeScript(stripAst(ast1Clone, 'loc')) === serializeScript(stripAst(ast2Clone, 'loc'))
-	);
+	const ast1Clone = stripAst(decircular(ast1), 'loc');
+	const ast2Clone = stripAst(decircular(ast2), 'loc');
+
+	return serializeScript(ast1Clone) === serializeScript(ast2Clone);
 }
 
 export function blockStatement() {
@@ -109,19 +108,20 @@ export function addStatement(
 	if (!hasNode(ast, statement)) ast.body.push(statement);
 }
 
-/** Returns `true` of the provided node exists in the AST */
+/** Returns `true` if the provided node exists in the AST */
 export function hasNode(ast: AstTypes.ASTNode, nodeToMatch: AstTypes.ASTNode): boolean {
 	let found = false;
 	// prettier-ignore
 	// this gets needlessly butchered by prettier
 	Walker.walk(ast, {}, {
-        _(node, { next, stop }) {
-            if (node.type === nodeToMatch.type) {
-                found = areNodesEqual(node, nodeToMatch);
-                if (found) stop();
-            }
-            next();
-        },
-    });
+		_(node, { next, stop }) {
+			if (node.type === nodeToMatch.type) {
+				found = areNodesEqual(node, nodeToMatch);
+				if (found) stop();
+			}
+			next();
+		},
+	});
+
 	return found;
 }

--- a/packages/ast-manipulation/js/exports.ts
+++ b/packages/ast-manipulation/js/exports.ts
@@ -75,4 +75,6 @@ export function namedExport(
 		declaration: fallback,
 	};
 	ast.body.push(namedExport);
+
+	return namedExport;
 }

--- a/packages/ast-manipulation/js/imports.ts
+++ b/packages/ast-manipulation/js/imports.ts
@@ -56,28 +56,28 @@ export function addNamed(
 		return specifier;
 	});
 
-	let declaration: AstTypes.ImportDeclaration | undefined;
+	let importDecl: AstTypes.ImportDeclaration | undefined;
 	// prettier-ignore
 	Walker.walk(ast as AstTypes.ASTNode, {}, {
 		ImportDeclaration(node) {
-			if (node.source.type === 'StringLiteral' && node.source.value === importFrom) {
-				declaration = node;
+			if (node.source.type === 'StringLiteral' && node.source.value === importFrom && node.specifiers) {
+				importDecl = node;
 			}
 		},
 	});
 
 	// merge the specifiers into a single import declaration if they share a source
-	if (declaration) {
-		specifiers.forEach((s) => {
+	if (importDecl) {
+		specifiers.forEach((specifierToAdd) => {
 			if (
-				declaration?.specifiers?.every(
-					(sp) =>
-						sp.type === 'ImportSpecifier' &&
-						sp.local?.name !== s.local?.name &&
-						sp.imported.name !== s.imported.name,
+				importDecl?.specifiers?.every(
+					(existingSpecifier) =>
+						existingSpecifier.type === 'ImportSpecifier' &&
+						existingSpecifier.local?.name !== specifierToAdd.local?.name &&
+						existingSpecifier.imported.name !== specifierToAdd.imported.name,
 				)
 			) {
-				declaration?.specifiers?.push(s);
+				importDecl?.specifiers?.push(specifierToAdd);
 			}
 		});
 		return;

--- a/packages/ast-manipulation/js/index.ts
+++ b/packages/ast-manipulation/js/index.ts
@@ -9,6 +9,7 @@ import type { AstTypes } from '@svelte-add/ast-tooling';
 
 export type JsAstEditor = {
 	ast: AstTypes.Program;
+	source: string;
 	common: typeof CommonUtils;
 	array: typeof ArrayUtils;
 	object: typeof ObjectUtils;
@@ -18,9 +19,10 @@ export type JsAstEditor = {
 	exports: typeof ExportUtils;
 };
 
-export function getJsAstEditor(ast: AstTypes.Program) {
+export function getJsAstEditor(ast: AstTypes.Program, source: string) {
 	const astEditor: JsAstEditor = {
 		ast,
+		source,
 		object: ObjectUtils,
 		common: CommonUtils,
 		array: ArrayUtils,

--- a/packages/ast-manipulation/js/variables.ts
+++ b/packages/ast-manipulation/js/variables.ts
@@ -43,3 +43,20 @@ export function identifier(name: string) {
 	};
 	return identifier;
 }
+
+export function typeAnnotateDeclarator(node: AstTypes.VariableDeclarator, typeName: string) {
+	if (node.id.type === 'Identifier') {
+		node.id.typeAnnotation = {
+			type: 'TSTypeAnnotation',
+			typeAnnotation: {
+				type: 'TSTypeReference',
+				typeName: {
+					type: 'Identifier',
+					name: typeName,
+				},
+			},
+		};
+	}
+
+	return node;
+}

--- a/packages/config/adders/official.ts
+++ b/packages/config/adders/official.ts
@@ -5,6 +5,7 @@ export const adderCategories: AdderCategories = {
 	testing: ['vitest', 'playwright'],
 	css: ['tailwindcss'],
 	db: ['drizzle'],
+	auth: ['lucia'],
 	additional: ['storybook', 'mdsvex', 'routify'],
 };
 

--- a/packages/config/categories.ts
+++ b/packages/config/categories.ts
@@ -4,7 +4,7 @@ export type CategoryInfo = {
 	description: string;
 };
 
-export type CategoryKeys = 'codeQuality' | 'css' | 'db' | 'testing' | 'additional';
+export type CategoryKeys = 'codeQuality' | 'css' | 'db' | 'testing' | 'additional' | 'auth';
 export type CategoryDetails = Record<CategoryKeys, CategoryInfo>;
 
 export type AdderCategories = Record<CategoryKeys, string[]>;
@@ -33,6 +33,11 @@ export const categories: CategoryDetails = {
 	db: {
 		id: 'db',
 		name: 'Database',
+		description: '',
+	},
+	auth: {
+		id: 'auth',
+		name: 'Auth',
 		description: '',
 	},
 };

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -48,6 +48,7 @@ export type BaseAdderConfig<Args extends OptionDefinition> = {
 	metadata: AdderConfigMetadata;
 	options: Args;
 	runsAfter?: string[];
+	dependsOn?: string[];
 	integrationType: string;
 };
 

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -30,7 +30,7 @@ import type {
 import type { RemoteControlOptions } from './remoteControl.js';
 import { suggestInstallingDependencies } from '../utils/dependencies.js';
 import { validatePreconditions } from './preconditions.js';
-import { endPrompts, startPrompts } from '../utils/prompts.js';
+import { endPrompts, startPrompts, booleanPrompt } from '../utils/prompts.js';
 import { checkPostconditions, printUnmetPostconditions } from './postconditions.js';
 import { displayNextSteps } from './nextSteps.js';
 import { spinner, log, cancel } from '@svelte-add/clack-prompts';
@@ -164,9 +164,16 @@ async function executePlan<Args extends OptionDefinition>(
 	// add inter-adder dependencies
 	for (const adder of userSelectedAdders) {
 		const details = adderDetails.find((a) => a.config.metadata.id === adder);
-		const deps =
+		const dependentAdders =
 			details?.config.dependsOn?.filter((dep) => !userSelectedAdders.includes(dep)) ?? [];
-		userSelectedAdders.push(...deps);
+
+		for (const dep of dependentAdders) {
+			const install = await booleanPrompt(
+				`The ${pc.bold(pc.cyan(adder))} adder requires ${pc.bold(pc.cyan(dep))} to also be installed. ${pc.green('Install it?')}`,
+				true,
+			);
+			if (install) userSelectedAdders.push(dep);
+		}
 	}
 
 	// remove unselected adder data

--- a/packages/core/adder/execute.ts
+++ b/packages/core/adder/execute.ts
@@ -161,6 +161,14 @@ async function executePlan<Args extends OptionDefinition>(
 	}
 	const isApplyingMultipleAdders = userSelectedAdders.length > 1;
 
+	// add inter-adder dependencies
+	for (const adder of userSelectedAdders) {
+		const details = adderDetails.find((a) => a.config.metadata.id === adder);
+		const deps =
+			details?.config.dependsOn?.filter((dep) => !userSelectedAdders.includes(dep)) ?? [];
+		userSelectedAdders.push(...deps);
+	}
+
 	// remove unselected adder data
 	const addersToRemove = adderDetails.filter(
 		(x) => !userSelectedAdders.includes(x.config.metadata.id),

--- a/packages/core/files/processors.ts
+++ b/packages/core/files/processors.ts
@@ -175,7 +175,7 @@ function handleSvelteFile<Args extends OptionDefinition>(
 	const { jsAst, htmlAst, cssAst } = parseSvelteFile(content);
 
 	fileDetails.content({
-		js: getJsAstEditor(jsAst),
+		js: getJsAstEditor(jsAst, content),
 		html: getHtmlAstEditor(htmlAst),
 		css: getCssAstEditor(cssAst),
 		...workspace,
@@ -201,7 +201,7 @@ function handleScriptFile<Args extends OptionDefinition>(
 	const ast = parseScript(content);
 
 	fileDetails.content({
-		...getJsAstEditor(ast),
+		...getJsAstEditor(ast, content),
 		...workspace,
 	});
 	content = serializeScript(ast);

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -23,3 +23,4 @@ export {
 };
 
 export type * from './files/processors.js';
+export { Walker, type AstTypes, type AstKinds } from '@svelte-add/ast-tooling';

--- a/packages/core/utils/workspace.ts
+++ b/packages/core/utils/workspace.ts
@@ -107,7 +107,7 @@ export async function parseSvelteConfigIntoWorkspace(workspace: WorkspaceWithout
 	if (!workspace.kit.installed) return;
 	const configText = await readFile(workspace, commonFilePaths.svelteConfigFilePath);
 	const ast = parseScript(configText);
-	const editor = getJsAstEditor(ast);
+	const editor = getJsAstEditor(ast, configText);
 
 	const defaultExport = ast.body.find((s) => s.type === 'ExportDefaultDeclaration');
 	if (!defaultExport) throw Error('Missing default export in `svelte.config.js`');

--- a/packages/dev-utils/utils/update-dependencies.ts
+++ b/packages/dev-utils/utils/update-dependencies.ts
@@ -23,6 +23,7 @@ async function updateAdderDependencies() {
 		const content = (await readFile(filePath)).toString();
 		const { ast, exports, functions, object, array, variables, common } = getJsAstEditor(
 			parseScript(content),
+			content,
 		);
 
 		const defineAdderConfig = functions.call('defineAdderConfig', []);


### PR DESCRIPTION
# WIP

- [x] missing a lot of error handling
- [x] need to gracefully handle existing `user` and `session` tables
- [x] implement named import merging (e.g. append new import specifiers to existing named imports if the sources match)
- [ ] figure out why comments are not preserved for the `app.d.ts` modifications
- [x] still need to implement the logic for `hooks.server.ts`
- [x] add a demo option (mainly based off of the SK example from [lucia's examples repo](https://github.com/lucia-auth/examples/tree/main/sveltekit/username-and-password))
	- to avoid collisions with existing user logic, the demo is created under a new route `/demo` 
	- it features a combined login/register page (`/demo/login`) which mirrors the [Named Actions examples](https://kit.svelte.dev/docs/form-actions#named-actions) in the SvelteKit docs, and a logout action
- [x] link `lucia` to `drizzle`, such that when `lucia` is selected, `drizzle` also gets selected
    - a confirmation prompt was also added so that it can be ignored
- [ ] `db:push` for `better-sqlite3` is throwing an error. might be a bug in the newest drizzle-kit/orm version?
- [ ] cleanup and test