### PR TITLE
feat: add tailwindcss forms option

### DIFF
--- a/adders/tailwindcss/config/adder.ts
+++ b/adders/tailwindcss/config/adder.ts
@@ -17,17 +17,23 @@ export const adder = defineAdderConfig({
 	options,
 	integrationType: 'inline',
 	packages: [
-		{ name: 'tailwindcss', version: '^3.4.9', dev: true },
+		{ name: 'tailwindcss', version: '^3.4.10', dev: true },
 		{ name: 'autoprefixer', version: '^10.4.20', dev: true },
 		{
 			name: '@tailwindcss/typography',
-			version: '^0.5.14',
+			version: '^0.5.15',
 			dev: true,
 			condition: ({ options }) => options.typography,
 		},
 		{
+			name: '@tailwindcss/forms',
+			version: '^0.5.9',
+			dev: true,
+			condition: ({ options }) => options.forms,
+		},
+		{
 			name: 'prettier-plugin-tailwindcss',
-			version: '^0.6.5',
+			version: '^0.6.6',
 			dev: true,
 			condition: ({ prettier }) => prettier.installed,
 		},
@@ -69,6 +75,10 @@ export const adder = defineAdderConfig({
 
 				if (options.typography) {
 					const requireCall = functions.call('require', ['@tailwindcss/typography']);
+					array.push(pluginsArray, requireCall);
+				}
+				if (options.forms) {
+					const requireCall = functions.call('require', ['@tailwindcss/forms']);
 					array.push(pluginsArray, requireCall);
 				}
 			},

--- a/adders/tailwindcss/config/options.ts
+++ b/adders/tailwindcss/config/options.ts
@@ -6,4 +6,9 @@ export const options = defineAdderOptions({
 		default: false,
 		type: 'boolean',
 	},
+	forms: {
+		question: 'Do you want to use forms plugin?',
+		default: false,
+		type: 'boolean',
+	},
 });

--- a/adders/tailwindcss/config/tests.ts
+++ b/adders/tailwindcss/config/tests.ts
@@ -5,6 +5,9 @@ import type { SvelteFileEditorArgs } from '@svelte-add/core/files/processors.js'
 
 const divId = 'myDiv';
 const typographyDivId = 'myTypographyDiv';
+const formsInputId = 'myFormInput';
+
+const defaultOptions = { forms: false, typography: false };
 
 export const tests = defineAdderTests({
 	files: [
@@ -14,6 +17,7 @@ export const tests = defineAdderTests({
 			content: (editor) => {
 				prepareCoreTest(editor);
 				if (editor.options.typography) prepareTypographyTest(editor);
+				if (editor.options.forms) prepareFormsTest(editor);
 			},
 			condition: ({ kit }) => kit.installed,
 		},
@@ -23,12 +27,17 @@ export const tests = defineAdderTests({
 			content: (editor) => {
 				prepareCoreTest(editor);
 				if (editor.options.typography) prepareTypographyTest(editor);
+				if (editor.options.forms) prepareFormsTest(editor);
 			},
 			condition: ({ kit }) => !kit.installed,
 		},
 	],
 	options,
-	optionValues: [{ typography: false }, { typography: true }],
+	optionValues: [
+		defaultOptions,
+		{ ...defaultOptions, forms: true },
+		{ ...defaultOptions, typography: true },
+	],
 	tests: [
 		{
 			name: 'core properties',
@@ -51,6 +60,17 @@ export const tests = defineAdderTests({
 				await expectProperty(selector, 'text-decoration-line', 'line-through');
 			},
 		},
+		{
+			name: 'forms properties',
+			condition: ({ forms }) => forms,
+			run: async ({ expectProperty }) => {
+				const selector = '#' + formsInputId;
+				await expectProperty(selector, 'padding-top', '8px');
+				await expectProperty(selector, 'padding-left', '12px');
+				await expectProperty(selector, 'font-size', '18px');
+				await expectProperty(selector, 'line-height', '28px');
+			},
+		},
 	],
 });
 
@@ -64,4 +84,9 @@ function prepareTypographyTest<Args extends OptionDefinition>({
 }: SvelteFileEditorArgs<Args>) {
 	const div = html.element('p', { class: 'text-lg text-right line-through', id: typographyDivId });
 	html.appendElement(html.ast.childNodes, div);
+}
+
+function prepareFormsTest<Args extends OptionDefinition>({ html }: SvelteFileEditorArgs<Args>) {
+	const input = html.element('input', { type: 'email', class: 'text-lg', id: formsInputId });
+	html.appendElement(html.ast.childNodes, input);
 }


### PR DESCRIPTION
Added `@tailwindcss/forms` plugin option on the `tailwindcss` adder + test

Updated the tailwind package versions